### PR TITLE
Track candidates received out of order

### DIFF
--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -341,7 +341,7 @@ extension ChannelConfigurationViewController: SignalClientDelegate {
             remoteSenderClientId = senderClientId
         }
         setRemoteSenderClientId()
-        webRTCClient!.set(remoteSdp: sdp) { _ in
+        webRTCClient!.set(remoteSdp: sdp, clientId: senderClientId) { _ in
             print("Setting remote sdp and sending answer.")
             self.vc!.sendAnswer(recipientClientID: self.remoteSenderClientId!)
 
@@ -354,7 +354,7 @@ extension ChannelConfigurationViewController: SignalClientDelegate {
             remoteSenderClientId = senderClientId
         }
         setRemoteSenderClientId()
-        webRTCClient!.set(remoteCandidate: candidate)
+        webRTCClient!.set(remoteCandidate: candidate, clientId: senderClientId)
     }
 }
 

--- a/Swift/KVSiOSApp/VideoViewController.swift
+++ b/Swift/KVSiOSApp/VideoViewController.swift
@@ -81,6 +81,8 @@ class VideoViewController: UIViewController {
     func sendAnswer(recipientClientID: String) {
         webRTCClient.answer { localSdp in
             self.signalingClient.sendAnswer(rtcSdp: localSdp, recipientClientId: recipientClientID)
+            print("Sent answer. Update peer connection map and handle pending ice candidates")
+            self.webRTCClient.updatePeerConnectionAndHandleIceCandidates(clientId: recipientClientID)
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
#30 

*Description of changes:*

Due to the out of order message delivery nature and specially under trickle ICE scenario, it is possible that the Android SDK receives ICE Candidates before receiving an offer (when android is master) or answer (when android is viewer). Host candidates are usually the first ones to be received/sent and if SDP exchange is not completed, the addIceCandidate call fails and host candidates are not added for gathering. This leads to a case where the probability of non-host candidates getting selected increases even when a connection with host candidates is possible, increasing TURN candidates selection ratio. This PR addresses the issue by queuing up the ICE candidates received before peer connection is established, that leads to using host candidates as well in connectivity checks. One thing to note is, unlike android, where adding ICE candidate fails with a boolean flag, in iOS that does not seem to be the case. Nevertheless, without this change, at times, it is observed that relay candidates are chosen over host even when host is a viable option.

Testing:

A manual testing was done using iOS as viewer and C SDK as master. The selection of host candidate was verified through RTCStats by first checking for the `"googActiveConnection": "true"` in the stats and then referencing the selected remote ice candidate in the stats report.

Sample code to extract CandidatePair stats:

```
    func testStats() {
        peerConnection.stats(for: nil, statsOutputLevel: RTCStatsOutputLevel.debug) { [weak self] reports in
            for report in reports {
                if(report.reportId.contains("Conn-")) {
                    print("Report pair: \(report.values)")
                }
            }
        }
    }
```

For the case of iOS as master, a dry test was done to ensure the flags and queues are appropriately updated. This scenario would still require more targeted testing.

Testing was also done for multi iOS viewers the same way to ensure nothing is broken.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
