### PR TITLE
WSS URL signing percentage encoding issue

### DIFF
--- a/Swift/KVSiOSApp/KVSSigner.swift
+++ b/Swift/KVSiOSApp/KVSSigner.swift
@@ -213,7 +213,7 @@ class KVSSigner {
                 if let index = param.firstIndex(of: "=") {
                     let nextIndex = param.index(after: index)
                     queryParamsBuilderDict.updateValue(String(param[nextIndex...]).addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!, forKey: String(param[..<index]))
-                    queryParamsBuilder.append(URLQueryItem(name: String(param[..<index].addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!), value: String(param[nextIndex...])))
+                    queryParamsBuilder.append(URLQueryItem(name: String(param[..<index].addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!), value: String(param[nextIndex...]).addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!))
                 }
             }
         } else {


### PR DESCRIPTION
WSS URL signing percentage encoding  was missed for X-Amz-ChannelARN key in queryParamsBuilder, because of that signalling socket connection was failing, have fixed this

