### PR TITLE
Add user agent when connecting to Signaling

### DIFF
--- a/Swift/KVSiOSApp/Constants.swift
+++ b/Swift/KVSiOSApp/Constants.swift
@@ -11,7 +11,7 @@ let cognitoIdentityUserPoolAppClientSecret = "REPLACEME"
 let cognitoIdentityPoolId = "REPLACEME"
 
 // App constants
-let appName = "aws-kvs-webrtc-android-client"
+let appName = "aws-kvs-webrtc-ios-client"
 let appVersion = "1.0.0"
 
 // KinesisVideo constants

--- a/Swift/KVSiOSApp/Constants.swift
+++ b/Swift/KVSiOSApp/Constants.swift
@@ -10,6 +10,10 @@ let cognitoIdentityUserPoolAppClientId = "REPLACEME"
 let cognitoIdentityUserPoolAppClientSecret = "REPLACEME"
 let cognitoIdentityPoolId = "REPLACEME"
 
+// App constants
+let appName = "aws-kvs-webrtc-android-client"
+let appVersion = "1.0.0"
+
 // KinesisVideo constants
 let awsKinesisVideoKey = "kinesisvideo"
 let videoProtocols =  ["WSS", "HTTPS"]
@@ -21,6 +25,8 @@ let connectAsViewerKey = "connect-as-viewer"
 let masterRole = "MASTER"
 let viewerRole = "VIEWER"
 let connectAsViewClientId = "ConsumerViewer"
+
+let userAgentHeader = "User-Agent"
 
 // AWSv4 signer constants
 let signerAlgorithm = "AWS4-HMAC-SHA256"

--- a/Swift/KVSiOSApp/SignalingClient.swift
+++ b/Swift/KVSiOSApp/SignalingClient.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Starscream
+import WebKit
 import WebRTC
 
 // interface for remote connectivity events
@@ -16,7 +17,16 @@ final class SignalingClient {
     weak var delegate: SignalClientDelegate?
 
     init(serverUrl: URL) {
-        socket = WebSocket(url: serverUrl)
+        var request: URLRequest = URLRequest(url: serverUrl)
+
+        let UA = WKWebView().value(forKey: "userAgent") as? String?
+        if let agent = UA {
+            request.setValue(appName + "/" + appVersion + " " + agent!, forHTTPHeaderField: userAgentHeader)
+        } else {
+            request.setValue(appName + "/" + appVersion, forHTTPHeaderField: userAgentHeader)
+        }
+        
+        socket = WebSocket(request: request)
     }
 
     func connect() {


### PR DESCRIPTION
*Description of changes:*
Add user agent, to make it easier for the team to identify which clients are connecting and/or experiencing errors with signaling.

Previously, there was no user agent present in the request (confirmed via service logs).

Now:
```
aws-kvs-webrtc-ios-client/1.0.0 Mozilla/5.0 (iPhone; CPU iPhone OS 16_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
```

Testing:
* Unit tests pass
* Manually tested the application with the JS test page, iOS, android, C SDK's - verified that we can see the media on both ends (regular path still working).
* Confirmed with backend team that they are receiving the updated user agent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
