### PR TITLE
Disable JS in WebView

### DIFF
--- a/Swift/KVSiOSApp/SignalingClient.swift
+++ b/Swift/KVSiOSApp/SignalingClient.swift
@@ -19,7 +19,10 @@ final class SignalingClient {
     init(serverUrl: URL) {
         var request: URLRequest = URLRequest(url: serverUrl)
 
-        let UA = WKWebView().value(forKey: "userAgent") as? String?
+        let webView = WKWebView()
+        webView.configuration.preferences.javaScriptEnabled = false
+
+        let UA = webView.value(forKey: "userAgent") as? String?
         if let agent = UA {
             request.setValue(appName + "/" + appVersion + " " + agent!, forHTTPHeaderField: userAgentHeader)
         } else {


### PR DESCRIPTION
This fixes the "JavaScript should be disabled in WebViews unless explicitly required." warning.

Tested using iOS<->JS alternating master/viewer and "force turn"/relay.

<br>
<br>
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
