### PR TITLE
Add comments with instructions for when using an app client without a client secret

### DIFF
--- a/Swift/KVSiOSApp/Constants.swift
+++ b/Swift/KVSiOSApp/Constants.swift
@@ -4,10 +4,10 @@ import AWSCognitoIdentityProvider
 // Cognito constants
 let awsCognitoUserPoolsSignInProviderKey = "UserPool"
 
-let cognitoIdentityUserPoolRegion = AWSRegionType.Unknown //  <- REPLACE ME!
+let cognitoIdentityUserPoolRegion = AWSRegionType.Unknown // <- REPLACE ME!
 let cognitoIdentityUserPoolId = "REPLACEME"
 let cognitoIdentityUserPoolAppClientId = "REPLACEME"
-let cognitoIdentityUserPoolAppClientSecret = "REPLACEME"
+let cognitoIdentityUserPoolAppClientSecret = "REPLACEME" // <- Leave blank "" if AppClient does not use a client secret.
 let cognitoIdentityPoolId = "REPLACEME"
 
 // App constants

--- a/Swift/KVSiOSApp/awsconfiguration.json
+++ b/Swift/KVSiOSApp/awsconfiguration.json
@@ -13,7 +13,7 @@
     },
     "CognitoUserPool": {
         "Default": {
-            "AppClientSecret": "REPLACEME",
+            "AppClientSecret": "REPLACEME - or remove this line if AppClient does not use a client secret.",
             "AppClientId": "REPLACEME",
             "PoolId": "REPLACEME",
             "Region": "REPLACEME"


### PR DESCRIPTION
When using a Cognito app client without a client secret,
- The `AppClientSecret` property in _awsconfiguration.json_ must be completely removed. Setting it to blank `""` causes an `(AWSMobileClient.AWSMobileClientError error 8.)` (invalidParameter) error upon signing in on the app.
- The `cognitoIdentityUserPoolAppClientSecret` in _Constants.swift_ variable should be left blank.

This is especially helpful considering that the default value for "Client secret" when creating an app client on the AWS console is "Don't generate a client secret".

This is in contrast to the KVS WebRTC Android SDK which can set `AppClientSecret` to `""` in _awsconfiguration.json_ when not using a secret.

<br>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
