### PR TITLE
Fix KVSSigner iso8601() issue with 12-hour format

### DIFF
--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -170,7 +170,17 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         }
         // get signalling channel endpoints
         let endpoints = getSignallingEndpoints(channelARN: channelARN!, region: awsRegionValue, isMaster: self.isMaster, useMediaServer: usingMediaServer)
+        //// Ensure that the WebSocket (WSS) endpoint is available; WebRTC requires a valid signaling endpoint.
+        if endpoints["WSS"] == nil {
+            popUpError(title: "Invalid SignallingEndpoints", message: "SignallingEndpoints is required for WebRTC connection")
+            return
+        }
         let wssURL = createSignedWSSUrl(channelARN: channelARN!, region: awsRegionValue, wssEndpoint: endpoints["WSS"]!, isMaster: self.isMaster)
+        // Ensure that the signed WebSocket URL is successfully created; a valid signed URL is required to establish a WebRTC connection.
+        if wssURL == nil {
+            popUpError(title: "Failed to create signed WSSUrl", message: "SignedWSSUrl is required for WebRTC connection")
+            return
+        }
         print("WSS URL :", wssURL?.absoluteString as Any)
         // get ice candidates using https endpoint
         let httpsEndpoint =

--- a/Swift/KVSiOSApp/KVSSigner.swift
+++ b/Swift/KVSiOSApp/KVSSigner.swift
@@ -63,6 +63,8 @@ class KVSSigner {
     static func iso8601() -> (fullDateTimestamp: String, shortDate: String) {
         let dateFormatter: DateFormatter = DateFormatter()
         dateFormatter.dateFormat = utcDateFormatter
+        // Ensures the date format is consistent regardless of the device's regional settings, preventing issues with 12-hour vs. 24-hour time formats.
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
         dateFormatter.timeZone = TimeZone(abbreviation: utcTimezone)
         let date = Date()
         let dateString = dateFormatter.string(from: date)
@@ -143,6 +145,7 @@ class KVSSigner {
         queryParamsBuilderArray.append(URLQueryItem(name: xAmzSignature, value: signature))
 
         if #available(iOS 11.0, *) {
+            // ensuring that special characters (such as spaces in timestamps) are handled correctly.
             components.percentEncodedQueryItems = queryParamsBuilderArray
         } else {
             


### PR DESCRIPTION
*Issue #, if available:*
If the phone's time format is set to a 12-hour system, the iso8601() method in KVSSigner returns a datetime string with a space, e.g., "20250315T73633 AMZ". This causes a crash at line 147 in KVSSigner, where components.percentEncodedQueryItems = queryParamsBuilderArray. This issue has been fixed.

*Description of changes:*
Fixed an issue in KVSSigner.iso8601() where the 12-hour time format included a space (e.g., "20250315T73633 AMZ"), causing a crash at line 147 when setting components.percentEncodedQueryItems.

Testing:
- Unit tests pass
- Manually tested the application with the JS test page, iOS, C SDK's - verified that we can see the media on both ends.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
