### PR TITLE
Update CI to latest iOS 18.0 -> iOS 18.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           {mac_ver: "13", xc_ver: "15.2", os: "17.2", iphone_ver: "14"},
           {mac_ver: "14", xc_ver: "15.4", os: "17.5", iphone_ver: "15"},
           {mac_ver: "15", xc_ver: "15.4", os: "17.5", iphone_ver: "15 Pro"},
-          {mac_ver: "15", xc_ver: "16.0", os: "18.0", iphone_ver: "16"}
+          {mac_ver: "15", xc_ver: "16.3", os: "18.4", iphone_ver: "16"}
         ]
       fail-fast: false
     runs-on: macos-${{ matrix.config.mac_ver }}
@@ -49,7 +49,7 @@ jobs:
           {mac_ver: "13", xc_ver: "15.2", os: "17.2", iphone_ver: "14"},
           {mac_ver: "14", xc_ver: "15.4", os: "17.5", iphone_ver: "15"},
           {mac_ver: "15", xc_ver: "15.4", os: "17.5", iphone_ver: "15 Pro"},
-          {mac_ver: "15", xc_ver: "16.0", os: "18.0", iphone_ver: "16"}
+          {mac_ver: "15", xc_ver: "16.3", os: "18.4", iphone_ver: "16"}
         ]
       fail-fast: false
     runs-on: macos-${{ matrix.config.mac_ver }}


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- Bumping the iOS from 18.0 to 18.4
- Note: 18.5 is not currently supported in the github runner, only up to 18.4 https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
