### PR TITLE
Disambiguate WebSocket

### DIFF
--- a/Swift/KVSiOSApp/SignalingClient.swift
+++ b/Swift/KVSiOSApp/SignalingClient.swift
@@ -12,7 +12,7 @@ protocol SignalClientDelegate: class {
 }
 
 final class SignalingClient {
-    private let socket: WebSocket
+    private let socket: Starscream.WebSocket
     private let encoder = JSONEncoder()
     weak var delegate: SignalClientDelegate?
 


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/daltoniam/Starscream/issues/1057

*Description of changes:*
- Adding `Starscream.` to resolve the ambiguous import error for WebSocket in iOS 26

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
