### PR TITLE
Update MacOS15 runner from XCode 15.4 -> 16.4 since it doesn't exist anymore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
         config: [
           {mac_ver: "13", xc_ver: "15.2", os: "17.2", iphone_ver: "14"},
           {mac_ver: "14", xc_ver: "15.4", os: "17.5", iphone_ver: "15"},
-          {mac_ver: "15", xc_ver: "15.4", os: "17.5", iphone_ver: "15 Pro"},
-          {mac_ver: "15", xc_ver: "16.3", os: "18.4", iphone_ver: "16"}
+          {mac_ver: "15", xc_ver: "16.4", os: "18.6", iphone_ver: "16e"},
+          {mac_ver: "15", xc_ver: "16.4", os: "18.6", iphone_ver: "16 Pro"}
         ]
       fail-fast: false
     runs-on: macos-${{ matrix.config.mac_ver }}
@@ -48,8 +48,8 @@ jobs:
         config: [
           {mac_ver: "13", xc_ver: "15.2", os: "17.2", iphone_ver: "14"},
           {mac_ver: "14", xc_ver: "15.4", os: "17.5", iphone_ver: "15"},
-          {mac_ver: "15", xc_ver: "15.4", os: "17.5", iphone_ver: "15 Pro"},
-          {mac_ver: "15", xc_ver: "16.3", os: "18.4", iphone_ver: "16"}
+          {mac_ver: "15", xc_ver: "16.4", os: "18.6", iphone_ver: "16e"},
+          {mac_ver: "15", xc_ver: "16.4", os: "18.6", iphone_ver: "16 Pro"}
         ]
       fail-fast: false
     runs-on: macos-${{ matrix.config.mac_ver }}


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- Bump the XCode Version used in the GitHub actions runner.
- Reviewed https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md for the available versions.
- Tested on a forked environment so this should work

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
