### PR TITLE
Support for alternate credentials option

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Complete the following steps:
 * _This sample application has been tested in Simulator (iPhone 16e) and iPhone SE 2nd Generation._
 
 
-#### Using user-provided AWS credentials directly instead of Cognito integration
+#### Using user-provided AWS credentials
 
 > [!IMPORTANT]
 > This is not recommended for production use.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ Complete the following steps:
 > [!IMPORTANT]
 > This is not recommended for production use.
 
-In the `Constants.swift`, set variables `awsAccessKey` and `awsSecretKey` (optional: `awsSessionToken`) with your values.
+In the top navigation of the XCode UI, choose "Product" > "Scheme" > "Edit Scheme". Choose "Run", "Environment Variables"
+and set the "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", (optional: "AWS_SESSION_TOKEN") environment variables.
+
 In this mode, your `awsconfiguration.json` does not need to be modified, and neither do the `REPLACEME` values
 in the `Constants.swift`.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,17 @@ Complete the following steps:
 
 ##### Note
 
-* _This sample application has been tested in iPhone XS and iPhone 6._
+* _This sample application has been tested in Simulator (iPhone 16e) and iPhone SE 2nd Generation._
+
+
+#### Using AWS credentials directly instead of Cognito
+
+> [!IMPORTANT]
+> This is not recommended for production use.
+
+In the `Constants.swift`, replaces awsAccessKey and awsSecretKey (optional: awsSessionToken) with your values.
+
+Upon launching the application, it will skip the sign in screen and go straight to the channel configuration screen.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -146,14 +146,16 @@ Complete the following steps:
 * _This sample application has been tested in Simulator (iPhone 16e) and iPhone SE 2nd Generation._
 
 
-#### Using AWS credentials directly instead of Cognito
+#### Using user-provided AWS credentials directly instead of Cognito integration
 
 > [!IMPORTANT]
 > This is not recommended for production use.
 
-In the `Constants.swift`, replaces awsAccessKey and awsSecretKey (optional: awsSessionToken) with your values.
+In the `Constants.swift`, set variables `awsAccessKey` and `awsSecretKey` (optional: `awsSessionToken`) with your values.
+In this mode, your `awsconfiguration.json` does not need to be modified, and neither do the `REPLACEME` values
+in the `Constants.swift`.
 
-Upon launching the application, it will skip the sign in screen and go straight to the channel configuration screen.
+Those user-provided credentials will be used to interact with KVS APIs instead of using credentials fetched from AWS Cognito Service.
 
 ## Troubleshooting
 

--- a/Swift/KVSiOSApp/AppDelegate.swift
+++ b/Swift/KVSiOSApp/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Check if AWS credentials are provided to bypass Cognito
         if let accessKey = awsAccessKey, let secretKey = awsSecretKey, !accessKey.isEmpty, !secretKey.isEmpty {
             // Use static AWS credentials
-            print("Bypassing Cognito sign-in screen")
+            print("Skipping Cognito sign-in screen")
             print("⚠️ WARNING: Using static AWS credentials - FOR PROTOTYPING ONLY, DO NOT USE IN PRODUCTION!")
 
             // Skip to channel configuration

--- a/Swift/KVSiOSApp/AppDelegate.swift
+++ b/Swift/KVSiOSApp/AppDelegate.swift
@@ -15,9 +15,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
+        // Do not show Cognito sign-in screen and go directly to channel configuration screen
+        // when not using Cognito integration
         if let accessKey = awsAccessKey, let secretKey = awsSecretKey, !accessKey.isEmpty, !secretKey.isEmpty {
-            // Use static AWS credentials
-            print("Skipping Cognito sign-in screen")
             print("⚠️ WARNING: Using static AWS credentials - FOR PROTOTYPING ONLY, DO NOT USE IN PRODUCTION!")
 
             // Skip to channel configuration

--- a/Swift/KVSiOSApp/AppDelegate.swift
+++ b/Swift/KVSiOSApp/AppDelegate.swift
@@ -15,8 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
-        // Do not show Cognito sign-in screen and go directly to channel configuration screen
-        // when not using Cognito integration
+        // Application uses the user provided test IAM credentials through environment (testing only)
         if let accessKey = awsAccessKey, !accessKey.isEmpty,
            let secretKey = awsSecretKey, !secretKey.isEmpty {
             print("⚠️ WARNING: Using static AWS credentials - FOR PROTOTYPING ONLY, DO NOT USE IN PRODUCTION!")

--- a/Swift/KVSiOSApp/AppDelegate.swift
+++ b/Swift/KVSiOSApp/AppDelegate.swift
@@ -17,7 +17,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Do not show Cognito sign-in screen and go directly to channel configuration screen
         // when not using Cognito integration
-        if let accessKey = awsAccessKey, let secretKey = awsSecretKey, !accessKey.isEmpty, !secretKey.isEmpty {
+        if let accessKey = awsAccessKey, !accessKey.isEmpty,
+           let secretKey = awsSecretKey, !secretKey.isEmpty {
             print("⚠️ WARNING: Using static AWS credentials - FOR PROTOTYPING ONLY, DO NOT USE IN PRODUCTION!")
 
             // Skip to channel configuration

--- a/Swift/KVSiOSApp/AppDelegate.swift
+++ b/Swift/KVSiOSApp/AppDelegate.swift
@@ -15,6 +15,22 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
+        // Check if AWS credentials are provided to bypass Cognito
+        if let accessKey = awsAccessKey, let secretKey = awsSecretKey, !accessKey.isEmpty, !secretKey.isEmpty {
+            // Use static AWS credentials
+            print("Bypassing Cognito sign-in screen")
+            print("⚠️ WARNING: Using static AWS credentials - FOR PROTOTYPING ONLY, DO NOT USE IN PRODUCTION!")
+
+            // Skip to channel configuration
+            self.storyboard = UIStoryboard(name: "Main", bundle: nil)
+            self.navigationController = self.storyboard?.instantiateViewController(withIdentifier: "channelConfig") as? UINavigationController
+            self.channelConfigViewController = self.navigationController?.viewControllers[0] as? ChannelConfigurationViewController
+            DispatchQueue.main.async {
+                self.window?.rootViewController?.present(self.navigationController!, animated: true, completion: nil)
+            }
+            return true
+        }
+
         // Warn user if configuration not updated
         if (cognitoIdentityUserPoolId == "REPLACEME") {
             let alertController = UIAlertController(title: "Invalid Configuration",

--- a/Swift/KVSiOSApp/AppDelegate.swift
+++ b/Swift/KVSiOSApp/AppDelegate.swift
@@ -15,7 +15,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
 
-        // Check if AWS credentials are provided to bypass Cognito
         if let accessKey = awsAccessKey, let secretKey = awsSecretKey, !accessKey.isEmpty, !secretKey.isEmpty {
             // Use static AWS credentials
             print("Skipping Cognito sign-in screen")

--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -110,7 +110,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
 
     @IBAction func signOut(_ sender: AnyObject) {
 
-        // When using IAM credentials for development testing, do not return to Cognito sign-in screen
+        // Disable signout option (n/a) when testing with user provided credentials through environment
         if let accessKey = awsAccessKey, !accessKey.isEmpty,
             let secretKey = awsSecretKey, !secretKey.isEmpty {
             popUpError(title: "Using hard-coded AWS IAM credentials for development testing", message: "Do not use this in production")

--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -46,7 +46,8 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
 
     // Helper function to get appropriate credentials provider
     private func getCredentialsProvider() -> AWSCredentialsProvider {
-        if let accessKey = awsAccessKey, let secretKey = awsSecretKey, !accessKey.isEmpty, !secretKey.isEmpty {
+        if let accessKey = awsAccessKey, !accessKey.isEmpty,
+           let secretKey = awsSecretKey, !secretKey.isEmpty {
             print("⚠️ WARNING: Using static AWS credentials - FOR PROTOTYPING ONLY, DO NOT USE IN PRODUCTION!")
 
             if let sessionToken = awsSessionToken, !sessionToken.isEmpty {
@@ -110,7 +111,8 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
     @IBAction func signOut(_ sender: AnyObject) {
 
         // When using IAM credentials for development testing, do not return to Cognito sign-in screen
-        if let accessKey = awsAccessKey, let secretKey = awsSecretKey, !accessKey.isEmpty, !secretKey.isEmpty {
+        if let accessKey = awsAccessKey, !accessKey.isEmpty,
+            let secretKey = awsSecretKey, !secretKey.isEmpty {
             popUpError(title: "Using hard-coded AWS IAM credentials for development testing", message: "Do not use this in production")
             return
         }

--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -44,6 +44,20 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
     
     var peerConnection: RTCPeerConnection?
 
+    // Helper function to get appropriate credentials provider
+    private func getCredentialsProvider() -> AWSCredentialsProvider {
+        if let accessKey = awsAccessKey, let secretKey = awsSecretKey, !accessKey.isEmpty, !secretKey.isEmpty {
+            print("⚠️ WARNING: Using static AWS credentials - FOR PROTOTYPING ONLY, DO NOT USE IN PRODUCTION!")
+
+            if let sessionToken = awsSessionToken, !sessionToken.isEmpty {
+                return AWSBasicSessionCredentialsProvider(accessKey: accessKey, secretKey: secretKey, sessionToken: sessionToken)
+            } else {
+                return AWSStaticCredentialsProvider(accessKey: accessKey, secretKey: secretKey)
+            }
+        }
+        return AWSMobileClient.default()
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(true)
         self.signalingConnected = false
@@ -94,6 +108,11 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
     }
 
     @IBAction func signOut(_ sender: AnyObject) {
+        if let accessKey = awsAccessKey, let secretKey = awsSecretKey, !accessKey.isEmpty, !secretKey.isEmpty {
+            popUpError(title: "Using hard-coded credentials", message: "Do not use this in production")
+            return
+        }
+
         AWSMobileClient.default().signOut()
         let mainStoryBoard: UIStoryboard = UIStoryboard(name: "Main", bundle: nil)
         self.present((mainStoryBoard.instantiateViewController(withIdentifier: "signinController") as? UINavigationController)!, animated: true, completion: nil)
@@ -145,7 +164,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
             print("Generated clientID is \(self.localSenderId)")
         }
         // Kinesis Video Client Configuration
-        let configuration = AWSServiceConfiguration(region: awsRegionType, credentialsProvider: AWSMobileClient.default())
+        let configuration = AWSServiceConfiguration(region: awsRegionType, credentialsProvider: getCredentialsProvider())
         AWSKinesisVideo.register(with: configuration!, forKey: awsKinesisVideoKey)
 
         // Attempt to retrieve signalling channel.  If it does not exist create the channel
@@ -297,7 +316,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         let configuration =
             AWSServiceConfiguration(region: regionType,
                                     endpoint: endpoint,
-                                    credentialsProvider: AWSMobileClient.default())
+                                    credentialsProvider: getCredentialsProvider())
         AWSKinesisVideoSignaling.register(with: configuration!, forKey: awsKinesisVideoKey)
         let kvsSignalingClient = AWSKinesisVideoSignaling(forKey: awsKinesisVideoKey)
 
@@ -373,13 +392,16 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
     
     func createSignedWSSUrl(channelARN: String, region: String, wssEndpoint: String?, isMaster: Bool) -> URL? {
         // get AWS credentials to sign WSS Url with
-        var AWSCredentials : AWSCredentials?
-        AWSMobileClient.default().getAWSCredentials { credentials, _ in
-            AWSCredentials = credentials
-        }
+        var awsCreds : AWSCredentials?
+
+        getCredentialsProvider().credentials().continueWith { task in
+                awsCreds = task.result
+                return nil
+            }.waitUntilFinished()
         
-        while(AWSCredentials == nil){
-            usleep(5)
+        guard awsCreds != nil else {
+            popUpError(title: "Error fetching credentials", message: "Unable to fetch the credentials")
+            return nil
         }
 
         var httpURlString = wssEndpoint!
@@ -391,9 +413,9 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         let wssRequestURL = URL(string: wssEndpoint!)
         let wssURL = KVSSigner
             .sign(signRequest: httpRequestURL!,
-                  secretKey: (AWSCredentials?.secretKey)!,
-                  accessKey: (AWSCredentials?.accessKey)!,
-                  sessionToken: (AWSCredentials?.sessionKey)!,
+                  secretKey: (awsCreds?.secretKey)!,
+                  accessKey: (awsCreds?.accessKey)!,
+                  sessionToken: (awsCreds?.sessionKey ?? ""),
                   wssRequest: wssRequestURL!,
                   region: region)
         return wssURL

--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -108,8 +108,10 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
     }
 
     @IBAction func signOut(_ sender: AnyObject) {
+
+        // When using IAM credentials for development testing, do not return to Cognito sign-in screen
         if let accessKey = awsAccessKey, let secretKey = awsSecretKey, !accessKey.isEmpty, !secretKey.isEmpty {
-            popUpError(title: "Using hard-coded credentials", message: "Do not use this in production")
+            popUpError(title: "Using hard-coded AWS IAM credentials for development testing", message: "Do not use this in production")
             return
         }
 

--- a/Swift/KVSiOSApp/Constants.swift
+++ b/Swift/KVSiOSApp/Constants.swift
@@ -28,7 +28,7 @@ let connectAsViewClientId = "ConsumerViewer"
 
 let userAgentHeader = "User-Agent"
 
-// AWS Credentials (set these to bypass Cognito authentication)
+// AWS Credentials (set these to override Cognito authentication)
 // Not recommended to use this in production
 let awsAccessKey: String? = nil // "YOUR_ACCESS_KEY"
 let awsSecretKey: String? = nil // "YOUR_SECRET_KEY"

--- a/Swift/KVSiOSApp/Constants.swift
+++ b/Swift/KVSiOSApp/Constants.swift
@@ -28,7 +28,8 @@ let connectAsViewClientId = "ConsumerViewer"
 
 let userAgentHeader = "User-Agent"
 
-// AWS Credentials (set these to override Cognito authentication)
+// User-provided AWS Credentials to use when calling KVS APIs
+// Instead of fetching credentials from AWS Cognito service
 // Not recommended to use this in production
 let awsAccessKey: String? = nil // "YOUR_ACCESS_KEY"
 let awsSecretKey: String? = nil // "YOUR_SECRET_KEY"

--- a/Swift/KVSiOSApp/Constants.swift
+++ b/Swift/KVSiOSApp/Constants.swift
@@ -28,6 +28,12 @@ let connectAsViewClientId = "ConsumerViewer"
 
 let userAgentHeader = "User-Agent"
 
+// AWS Credentials (set these to bypass Cognito authentication)
+// Not recommended to use this in production
+let awsAccessKey: String? = nil // "YOUR_ACCESS_KEY"
+let awsSecretKey: String? = nil // "YOUR_SECRET_KEY"
+let awsSessionToken: String? = nil // "YOUR_SESSION_TOKEN", leave as nil if not using ephemeral credentials
+
 // AWSv4 signer constants
 let signerAlgorithm = "AWS4-HMAC-SHA256"
 let awsRequestTypeKey = "aws4_request"

--- a/Swift/KVSiOSApp/Constants.swift
+++ b/Swift/KVSiOSApp/Constants.swift
@@ -28,13 +28,6 @@ let connectAsViewClientId = "ConsumerViewer"
 
 let userAgentHeader = "User-Agent"
 
-// User-provided AWS Credentials to use when calling KVS APIs
-// Instead of fetching credentials from AWS Cognito service
-// Not recommended to use this in production
-let awsAccessKey: String? = nil // "YOUR_ACCESS_KEY"
-let awsSecretKey: String? = nil // "YOUR_SECRET_KEY"
-let awsSessionToken: String? = nil // "YOUR_SESSION_TOKEN", leave as nil if not using ephemeral credentials
-
 // AWSv4 signer constants
 let signerAlgorithm = "AWS4-HMAC-SHA256"
 let awsRequestTypeKey = "aws4_request"
@@ -62,3 +55,6 @@ let wssKey = "wss"
 let plusEncoding = "%2B"
 let equalsEncoding = "%3D"
 
+let awsAccessKey: String? = ProcessInfo.processInfo.environment["AWS_ACCESS_KEY_ID"]
+let awsSecretKey: String? = ProcessInfo.processInfo.environment["AWS_SECRET_ACCESS_KEY"]
+let awsSessionToken: String? = ProcessInfo.processInfo.environment["AWS_SESSION_TOKEN"]


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-ios/issues/84
- https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-ios/issues/61
- https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-ios/issues/41
- 

*Description of changes:*
- Added a way for developers to skip the Cognito provisioning step when using the app. This reduces the onboarding time by a significant amount and makes it easier to switch AWS accounts during app testing.
- Added warnings in the logs for when this method is used
- Added instructions in the README for how to set it up
- I renamed AWSCredentials variable to awsCreds due to a namespace conflict.

*Testing*
Verified with the [JS viewer](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/index.html) the following credential methods, and they all successfully establish the RTCPeerConnection.
- Cognito (recommended path)
- AccessKey+SecreteKey
- AccessKey+SecretKey+SessionToken

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
