### PR TITLE
Set arch to x86_64

### DIFF
--- a/Swift/AWSKinesisVideoWebRTCDemoApp.xcodeproj/project.pbxproj
+++ b/Swift/AWSKinesisVideoWebRTCDemoApp.xcodeproj/project.pbxproj
@@ -777,6 +777,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BDB1499CD0982C181C7DDE9E /* Pods-AWSKinesisVideoWebRTCDemoApp.debug.xcconfig */;
 			buildSettings = {
+				ARCHS = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
@@ -827,6 +828,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B7FFA0959C9A8A6DEFEA075F /* Pods-AWSKinesisVideoWebRTCDemoApp.release.xcconfig */;
 			buildSettings = {
+				ARCHS = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;

--- a/Swift/AWSKinesisVideoWebRTCDemoApp.xcodeproj/project.pbxproj
+++ b/Swift/AWSKinesisVideoWebRTCDemoApp.xcodeproj/project.pbxproj
@@ -659,6 +659,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
+				"ARCHS[sdk=iphonesimulator*]" = x86_64;
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -688,6 +690,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				EXCLUDED_ARCHS = arm64;
 				"FRAMEWORK_SEARCH_PATHS[arch=*]" = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
@@ -720,6 +723,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
+				"ARCHS[sdk=iphonesimulator*]" = x86_64;
+				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -750,6 +755,7 @@
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = NO;
+				EXCLUDED_ARCHS = arm64;
 				"FRAMEWORK_SEARCH_PATHS[arch=*]" = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/build/Debug-iphoneos",
@@ -777,7 +783,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BDB1499CD0982C181C7DDE9E /* Pods-AWSKinesisVideoWebRTCDemoApp.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;

--- a/Swift/AWSKinesisVideoWebRTCDemoApp.xcodeproj/project.pbxproj
+++ b/Swift/AWSKinesisVideoWebRTCDemoApp.xcodeproj/project.pbxproj
@@ -833,7 +833,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B7FFA0959C9A8A6DEFEA075F /* Pods-AWSKinesisVideoWebRTCDemoApp.release.xcconfig */;
 			buildSettings = {
-				ARCHS = x86_64;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adjust project build settings to `x86_64` rather than `arm64` in the XCode UI
<img width="1177" height="295" alt="image" src="https://github.com/user-attachments/assets/3189dc2b-6623-44a7-8b70-710f7d5615a9" />

- To resolve the following build error: "Unsupported Swift architecture"
<img width="339" height="215" alt="image" src="https://github.com/user-attachments/assets/52917351-ae95-442a-a733-048190d4c50e" />

This is because some libraries only support the x86_64 simulator, not the arm64 simulator. But the libraries support arm64 real devices (such as iPhone SE 2nd Gen).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
