### PR TITLE
Making SdpMid ICE candidate property optional

### DIFF
--- a/Swift/KVSiOSApp/SignalingClient.swift
+++ b/Swift/KVSiOSApp/SignalingClient.swift
@@ -136,15 +136,21 @@ extension SignalingClient: WebSocketDelegate {
                         debugPrint("SDP answer received from signaling \(sdp)")
                     } else if messageType == "ICE_CANDIDATE" {
                         guard let iceCandidate = jsonObject["candidate"] as? String else {
+                            print("Dropping \(jsonObject), due to missing 'candidate' property")
                             return
                         }
-                        guard let sdpMid = jsonObject["sdpMid"] as? String else {
+                        let sdpMid = jsonObject["sdpMid"] as? String
+                        let sdpMLineIndex = jsonObject["sdpMLineIndex"] as? Int32
+                        
+                        guard sdpMid != nil || sdpMLineIndex != nil else {
+                            print("Dropping \(jsonObject), both sdpMid and sdpMLineIndex missing (at least one must be present)")
                             return
                         }
-                        guard let sdpMLineIndex = jsonObject["sdpMLineIndex"] as? Int32 else {
-                            return
-                        }
-                        let rtcIceCandidate: RTCIceCandidate = RTCIceCandidate(sdp: iceCandidate, sdpMLineIndex: sdpMLineIndex, sdpMid: sdpMid)
+                        let rtcIceCandidate: RTCIceCandidate = RTCIceCandidate(
+                            sdp: iceCandidate,
+                            sdpMLineIndex: sdpMLineIndex ?? 0,
+                            sdpMid: sdpMid
+                        )
                         delegate?.signalClient(self, senderClientId: senderClientId!, didReceiveCandidate: rtcIceCandidate)
                         debugPrint("ICE candidate received from signaling \(iceCandidate)")
                     }


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- The signaling client currently requires the ICE candidate property: sdpMid and sdpMLineIndex all to be included in the ice candidate. However, according to https://developer.mozilla.org/en-US/docs/Web/API/RTCIceCandidate/sdpMid, either one needs to be provided, sdpMid and sdpMLineIndex, both are not required.
- Make it consistent with https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-android/pull/88
- Also added additional logging if an ICE candidate was dropped due to formatting issues

*Testing:*
- Checked that ICE candidates missing the sdpMid property are accepted and not dropped

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
