### PR TITLE
Resolution selector

### DIFF
--- a/Swift/KVSiOSApp/Main.storyboard
+++ b/Swift/KVSiOSApp/Main.storyboard
@@ -586,8 +586,22 @@
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3k1-42-Mbg">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="res-btn-123">
                                         <rect key="frame" x="0.0" y="204" width="243" height="25"/>
+                                        <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="25" id="res-height-123"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <state key="normal" title="1280x720">
+                                            <color key="titleColor" systemColor="labelColor"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="resolutionButtonTapped:" destination="fxY-gB-7Yj" eventType="touchUpInside" id="res-action-123"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3k1-42-Mbg">
+                                        <rect key="frame" x="0.0" y="272" width="250" height="25"/>
                                         <color key="backgroundColor" red="0.1960784314" green="0.60392156860000001" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <accessibility key="accessibilityConfiguration" identifier="connectasmasterbutton"/>
                                         <constraints>
@@ -672,6 +686,7 @@
                         <outlet property="connectedLabel" destination="NOw-C6-Bie" id="cMG-kR-3E9"/>
                         <outlet property="isAudioEnabled" destination="uWn-mC-EnS" id="CUs-sB-mgl"/>
                         <outlet property="regionName" destination="nr9-tN-CuW" id="tX6-zd-Kpw"/>
+                        <outlet property="resolutionButton" destination="res-btn-123" id="res-outlet-123"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7NB-jG-Ywn" userLabel="First Responder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- Add a configuration option to change the resolution of the camera.
- Previously, it would always choose the largest resolution (3088x2320 on the iPhone SE 2nd Gen)

Here is what the UI looks like:

<img height="700" alt="image" src="https://github.com/user-attachments/assets/a52dcd9e-879c-4f61-b820-aa021adf2c08" />
 
<img height="700" alt="image" src="https://github.com/user-attachments/assets/663aa4b1-ae14-4413-a90a-84a7e07e6384" />

*Testing*
- Manually checked the other side receives the appropriately sized video.
- Clicked the different resolutions and it gets updated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
