### PR TITLE
ControlPlaneURI override configuration option

### DIFF
--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -168,7 +168,9 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
             print("Generated clientID is \(self.localSenderId)")
         }
         // Kinesis Video Client Configuration
-        let configuration = AWSServiceConfiguration(region: awsRegionType, credentialsProvider: getCredentialsProvider())
+        let configuration = AWSServiceConfiguration(region: awsRegionType,
+                                                    endpoint: kvsControlPlaneOverride.map { AWSEndpoint(urlString: $0) },
+                                                    credentialsProvider: getCredentialsProvider())
         AWSKinesisVideo.register(with: configuration!, forKey: awsKinesisVideoKey)
 
         // Attempt to retrieve signalling channel.  If it does not exist create the channel

--- a/Swift/KVSiOSApp/Constants.swift
+++ b/Swift/KVSiOSApp/Constants.swift
@@ -58,3 +58,4 @@ let equalsEncoding = "%3D"
 let awsAccessKey: String? = ProcessInfo.processInfo.environment["AWS_ACCESS_KEY_ID"]
 let awsSecretKey: String? = ProcessInfo.processInfo.environment["AWS_SECRET_ACCESS_KEY"]
 let awsSessionToken: String? = ProcessInfo.processInfo.environment["AWS_SESSION_TOKEN"]
+let kvsControlPlaneOverride: String? = ProcessInfo.processInfo.environment["CONTROL_PLANE_URI"]


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*Description of changes:*
- Add an environment variable option to override the control plane URI, same as we have in the https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js
- If not provided, it is nil and uses the default endpoint (based on the region)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
