### PR TITLE
WebRTC ingestion support

### DIFF
--- a/Swift/AWSKinesisVideoWebRTCDemoApp.xcodeproj/project.pbxproj
+++ b/Swift/AWSKinesisVideoWebRTCDemoApp.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 					17FC2F7B1E258FC500174015 = {
 						CreatedOnToolsVersion = 7.3.1;
 						LastSwiftMigration = 1020;
+						ProvisioningStyle = Automatic;
 					};
 					703513E32399DA0400376B66 = {
 						CreatedOnToolsVersion = 11.2;
@@ -469,6 +470,7 @@
 				"${BUILT_PRODUCTS_DIR}/AWSCore/AWSCore.framework",
 				"${BUILT_PRODUCTS_DIR}/AWSKinesisVideo/AWSKinesisVideo.framework",
 				"${BUILT_PRODUCTS_DIR}/AWSKinesisVideoSignaling/AWSKinesisVideoSignaling.framework",
+				"${BUILT_PRODUCTS_DIR}/AWSKinesisVideoWebRTCStorage/AWSKinesisVideoWebRTCStorage.framework",
 				"${BUILT_PRODUCTS_DIR}/AWSMobileClient/AWSMobileClient.framework",
 				"${BUILT_PRODUCTS_DIR}/CommonCryptoModule/CommonCryptoModule.framework",
 				"${PODS_ROOT}/GoogleWebRTC/Frameworks/frameworks/WebRTC.framework",
@@ -482,6 +484,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSKinesisVideo.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSKinesisVideoSignaling.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSKinesisVideoWebRTCStorage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSMobileClient.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CommonCryptoModule.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WebRTC.framework",
@@ -527,6 +530,7 @@
 				"${BUILT_PRODUCTS_DIR}/AWSCore/AWSCore.framework",
 				"${BUILT_PRODUCTS_DIR}/AWSKinesisVideo/AWSKinesisVideo.framework",
 				"${BUILT_PRODUCTS_DIR}/AWSKinesisVideoSignaling/AWSKinesisVideoSignaling.framework",
+				"${BUILT_PRODUCTS_DIR}/AWSKinesisVideoWebRTCStorage/AWSKinesisVideoWebRTCStorage.framework",
 				"${BUILT_PRODUCTS_DIR}/AWSMobileClient/AWSMobileClient.framework",
 				"${BUILT_PRODUCTS_DIR}/CommonCryptoModule/CommonCryptoModule.framework",
 				"${PODS_ROOT}/GoogleWebRTC/Frameworks/frameworks/WebRTC.framework",
@@ -540,6 +544,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSKinesisVideo.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSKinesisVideoSignaling.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSKinesisVideoWebRTCStorage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSMobileClient.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CommonCryptoModule.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WebRTC.framework",
@@ -659,8 +664,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
-				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -723,8 +728,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
-				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -784,6 +789,8 @@
 			baseConfigurationReference = BDB1499CD0982C181C7DDE9E /* Pods-AWSKinesisVideoWebRTCDemoApp.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=*]" = "";
@@ -825,6 +832,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinesisvideo.KVSApp1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;

--- a/Swift/AWSKinesisVideoWebRTCDemoAppTests/VideoViewControllerTests.swift
+++ b/Swift/AWSKinesisVideoWebRTCDemoAppTests/VideoViewControllerTests.swift
@@ -20,9 +20,9 @@ class VideoViewControllerTests: XCTestCase{
         signalingClient!.connect()
         
         RTCIceServersList.append(RTCIceServer.init(urlStrings: ["stun:stun.kinesisvideo." + "us-west-2" + ".amazonaws.com:443"]))
-        webRTCClient = WebRTCClient(iceServers: RTCIceServersList, isAudioOn: true)
+        webRTCClient = WebRTCClient(iceServers: RTCIceServersList, isAudioOn: true, isVideoOn: true)
         webRTCClient!.delegate = channelVC
-        videoViewController = VideoViewController(webRTCClient: self.webRTCClient!, signalingClient: self.signalingClient!, localSenderClientID: "randomClientID", isMaster: true, mediaServerEndPoint: nil)
+        videoViewController = VideoViewController(webRTCClient: self.webRTCClient!, signalingClient: self.signalingClient!, localSenderClientID: "randomClientID", isMaster: true, signalingChannelArn: nil)
     }
     
     override func tearDown() {

--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -242,7 +242,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
                 // Master mode: Both audio and video required
                 popUpError(title: "Invalid Configuration", message: "Video and audio must be enabled for WebRTC ingestion master")
                 return
-            } else {
+            } else if (!self.isMaster) {
                 // Viewer mode: Video not allowed, audio optional
                 if (self.isVideoEnabled.isOn) {
                     popUpError(title: "Invalid Configuration", message: "Video is not allowed for WebRTC ingestion viewer")

--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -235,9 +235,9 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
             }
         }
         // check whether signalling channel will save its recording to a stream
-        var usingMediaServer: Bool = isUsingMediaServer(channelARN: channelARN!, channelName: channelNameValue)
+        var useStorageSession: Bool = isUsingStorageSession(channelARN: channelARN!, channelName: channelNameValue)
         // Make sure that audio is enabled if ingesting webrtc connection
-        if(usingMediaServer) {
+        if (useStorageSession) {
             if (self.isMaster && (!self.isAudioEnabled.isOn || !self.isVideoEnabled.isOn)) {
                 // Master mode: Both audio and video required
                 popUpError(title: "Invalid Configuration", message: "Video and audio must be enabled for WebRTC ingestion master")
@@ -252,7 +252,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         }
 
         // get signalling channel endpoints
-        let endpoints = getSignallingEndpoints(channelARN: channelARN!, region: awsRegionValue, isMaster: self.isMaster, useMediaServer: usingMediaServer)
+        let endpoints = getSignallingEndpoints(channelARN: channelARN!, region: awsRegionValue, isMaster: self.isMaster, useStorageSession: useStorageSession)
         //// Ensure that the WebSocket (WSS) endpoint is available; WebRTC requires a valid signaling endpoint.
         if endpoints["WSS"] == nil {
             popUpError(title: "Invalid SignallingEndpoints", message: "SignallingEndpoints is required for WebRTC connection")
@@ -274,11 +274,11 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         webRTCClient = WebRTCClient(iceServers: RTCIceServersList, isAudioOn: sendAudioEnabled, isVideoOn: sendVideoEnabled, resolution: selectedResolution)
         webRTCClient!.delegate = self
         
-        guard !usingMediaServer || endpoints["WEBRTC"] != nil else {
+        guard !useStorageSession || endpoints["WEBRTC"] != nil else {
             print("connectAsRole IllegalState! WEBRTC endpoint is required for WebRTC ingestion")
             return
         }
-        if usingMediaServer {
+        if useStorageSession {
             let webRTCEndpoint: String = endpoints["WEBRTC"]!!
             let webRTCStorageConfiguration = AWSServiceConfiguration(region: awsRegionType,
                                                                     endpoint: AWSEndpoint(urlString: webRTCEndpoint),
@@ -296,7 +296,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         let seconds = 2.0
         DispatchQueue.main.asyncAfter(deadline: .now() + seconds) {
             self.updateConnectionLabel()
-            self.vc = VideoViewController(webRTCClient: self.webRTCClient!, signalingClient: self.signalingClient!, localSenderClientID: self.localSenderId, isMaster: self.isMaster, signalingChannelArn: usingMediaServer ? channelARN : nil, isVideoEnabled: self.sendVideoEnabled)
+            self.vc = VideoViewController(webRTCClient: self.webRTCClient!, signalingClient: self.signalingClient!, localSenderClientID: self.localSenderId, isMaster: self.isMaster, signalingChannelArn: useStorageSession ? channelARN : nil, isVideoEnabled: self.sendVideoEnabled)
             self.present(self.vc!, animated: true, completion: nil)
         }
     }
@@ -356,8 +356,8 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         return channelARN
     }
     
-    // check media server is enabled for signalling channel
-    func isUsingMediaServer(channelARN: String, channelName: String) -> Bool {
+    // check storage session (WebRTC ingestion) is enabled for signalling channel
+    func isUsingStorageSession(channelARN: String, channelName: String) -> Bool {
         var usingMediaServer : Bool = false
         /*
             equivalent AWS CLI command:
@@ -418,7 +418,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
     }
    
     // Get signalling endpoints for the given signalling channel ARN 
-    func getSignallingEndpoints(channelARN: String, region: String, isMaster: Bool, useMediaServer: Bool) -> Dictionary<String, String?> {
+    func getSignallingEndpoints(channelARN: String, region: String, isMaster: Bool, useStorageSession: Bool) -> Dictionary<String, String?> {
         
         var endpoints = Dictionary <String, String?>()
         /*
@@ -430,7 +430,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         singleMasterChannelEndpointConfiguration?.protocols = videoProtocols
         singleMasterChannelEndpointConfiguration?.role = getSingleMasterChannelEndpointRole(isMaster: isMaster)
         
-        if(useMediaServer){
+        if (useStorageSession){
             singleMasterChannelEndpointConfiguration?.protocols?.append("WEBRTC")
         }
  

--- a/Swift/KVSiOSApp/Main.storyboard
+++ b/Swift/KVSiOSApp/Main.storyboard
@@ -556,8 +556,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="43" translatesAutoresizingMaskIntoConstraints="NO" id="4pf-3f-52M">
-                                <rect key="frame" x="66" y="104" width="243" height="425.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="4pf-3f-52M">
+                                <rect key="frame" x="66" y="74" width="243" height="564.5"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Channel Name " textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zEP-tC-ik7">
                                         <rect key="frame" x="0.0" y="0.0" width="243" height="25"/>
@@ -569,7 +569,7 @@
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Client ID (optional)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="a2V-fh-lBx">
-                                        <rect key="frame" x="0.0" y="68" width="243" height="25"/>
+                                        <rect key="frame" x="0.0" y="65" width="243" height="25"/>
                                         <accessibility key="accessibilityConfiguration" identifier="clientidtextfield"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="25" id="drp-Hv-OMz"/>
@@ -578,7 +578,7 @@
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Region" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nr9-tN-CuW">
-                                        <rect key="frame" x="0.0" y="136" width="243" height="25"/>
+                                        <rect key="frame" x="0.0" y="130" width="243" height="25"/>
                                         <accessibility key="accessibilityConfiguration" identifier="regiontextfield"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="25" id="NqF-xK-94H"/>
@@ -587,7 +587,7 @@
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="res-btn-123">
-                                        <rect key="frame" x="0.0" y="204" width="243" height="25"/>
+                                        <rect key="frame" x="0.0" y="195" width="243" height="25"/>
                                         <color key="backgroundColor" systemColor="systemGrayColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="25" id="res-height-123"/>
@@ -601,7 +601,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3k1-42-Mbg">
-                                        <rect key="frame" x="0.0" y="272" width="250" height="25"/>
+                                        <rect key="frame" x="0.0" y="260" width="243" height="25"/>
                                         <color key="backgroundColor" red="0.1960784314" green="0.60392156860000001" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <accessibility key="accessibilityConfiguration" identifier="connectasmasterbutton"/>
                                         <constraints>
@@ -616,7 +616,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KMq-bs-4Hv">
-                                        <rect key="frame" x="0.0" y="272" width="243" height="25"/>
+                                        <rect key="frame" x="0.0" y="325" width="243" height="25"/>
                                         <color key="backgroundColor" red="0.1960784314" green="0.60392156860000001" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <accessibility key="accessibilityConfiguration" identifier="connectasviewerbutton"/>
                                         <constraints>
@@ -630,16 +630,34 @@
                                             <action selector="connectAsViewerWith_sender:" destination="fxY-gB-7Yj" eventType="touchUpInside" id="0T8-1E-4hO"/>
                                         </connections>
                                     </button>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="120" translatesAutoresizingMaskIntoConstraints="NO" id="G8H-J9-l8I">
-                                        <rect key="frame" x="0.0" y="340" width="243" height="28"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="120" translatesAutoresizingMaskIntoConstraints="NO" id="YHE-xZ-R4i">
+                                        <rect key="frame" x="0.0" y="390" width="243" height="52"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Audio" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pV1-OS-ahX">
-                                                <rect key="frame" x="0.0" y="0.0" width="62" height="28"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Send Video" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vLC-Za-qPN">
+                                                <rect key="frame" x="0.0" y="0.0" width="62" height="52"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="11"/>
-                                                <nil key="textColor"/>
+                                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uWn-mC-EnS">
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" title="Is Video Enabled" translatesAutoresizingMaskIntoConstraints="NO" id="Z0n-7n-HzH">
+                                                <rect key="frame" x="182" y="0.0" width="63" height="52"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="audioswitch"/>
+                                                <connections>
+                                                    <action selector="videoStateChangedWithSender:" destination="fxY-gB-7Yj" eventType="valueChanged" id="Vqg-xx-bxL"/>
+                                                </connections>
+                                            </switch>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="120" translatesAutoresizingMaskIntoConstraints="NO" id="G8H-J9-l8I">
+                                        <rect key="frame" x="0.0" y="482" width="243" height="28"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Send Audio" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pV1-OS-ahX">
+                                                <rect key="frame" x="0.0" y="0.0" width="62" height="28"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uWn-mC-EnS">
                                                 <rect key="frame" x="182" y="0.0" width="63" height="28"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="audioswitch"/>
                                                 <connections>
@@ -647,12 +665,9 @@
                                                 </connections>
                                             </switch>
                                         </subviews>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="50" id="H9p-0h-v6z"/>
-                                        </constraints>
                                     </stackView>
                                     <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Not Connected" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="NOw-C6-Bie">
-                                        <rect key="frame" x="0.0" y="411" width="200" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="550" width="243" height="14.5"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -664,7 +679,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="4pf-3f-52M" firstAttribute="centerX" secondItem="PaL-Mo-bUW" secondAttribute="centerX" id="NVI-gQ-wnE"/>
-                            <constraint firstItem="4pf-3f-52M" firstAttribute="top" secondItem="719-2R-FoQ" secondAttribute="bottom" constant="30" id="Zez-5g-7f3"/>
+                            <constraint firstItem="4pf-3f-52M" firstAttribute="top" secondItem="719-2R-FoQ" secondAttribute="bottom" id="Zez-5g-7f3"/>
                             <constraint firstItem="4pf-3f-52M" firstAttribute="leading" secondItem="PaL-Mo-bUW" secondAttribute="leadingMargin" constant="50" id="n2h-Cg-NaW"/>
                         </constraints>
                     </view>
@@ -685,6 +700,7 @@
                         <outlet property="connectAsViewerButton" destination="KMq-bs-4Hv" id="HDg-vF-0CB"/>
                         <outlet property="connectedLabel" destination="NOw-C6-Bie" id="cMG-kR-3E9"/>
                         <outlet property="isAudioEnabled" destination="uWn-mC-EnS" id="CUs-sB-mgl"/>
+                        <outlet property="isVideoEnabled" destination="Z0n-7n-HzH" id="q4o-zH-9LY"/>
                         <outlet property="regionName" destination="nr9-tN-CuW" id="tX6-zd-Kpw"/>
                         <outlet property="resolutionButton" destination="res-btn-123" id="res-outlet-123"/>
                     </connections>
@@ -709,7 +725,7 @@
                                 <rect key="frame" x="12" y="78" width="350" height="405"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gka-28-A0V">
-                                        <rect key="frame" x="0.0" y="0.0" width="350" height="200"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="350" height="180"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="350" id="845-y2-BGp"/>
@@ -717,7 +733,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jnz-Q7-NG2">
-                                        <rect key="frame" x="0.0" y="200" width="350" height="180"/>
+                                        <rect key="frame" x="0.0" y="180" width="350" height="200"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="200" id="EqQ-9O-HQK"/>
@@ -755,8 +771,14 @@
         </scene>
     </scenes>
     <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGrayColor">
+            <color red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Swift/KVSiOSApp/Main.storyboard
+++ b/Swift/KVSiOSApp/Main.storyboard
@@ -552,7 +552,7 @@
                         <viewControllerLayoutGuide type="top" id="719-2R-FoQ"/>
                         <viewControllerLayoutGuide type="bottom" id="xzu-VI-sNV"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="PaL-Mo-bUW" customClass="zz">
+                    <view key="view" contentMode="scaleToFill" id="PaL-Mo-bUW" customClass="View">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
@@ -725,7 +725,7 @@
                                 <rect key="frame" x="12" y="78" width="350" height="405"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gka-28-A0V">
-                                        <rect key="frame" x="0.0" y="0.0" width="350" height="180"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="350" height="200"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="350" id="845-y2-BGp"/>
@@ -733,7 +733,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jnz-Q7-NG2">
-                                        <rect key="frame" x="0.0" y="180" width="350" height="200"/>
+                                        <rect key="frame" x="0.0" y="200" width="350" height="180"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="200" id="EqQ-9O-HQK"/>
@@ -778,7 +778,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGrayColor">
-            <color red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Swift/KVSiOSApp/Main.storyboard
+++ b/Swift/KVSiOSApp/Main.storyboard
@@ -552,7 +552,7 @@
                         <viewControllerLayoutGuide type="top" id="719-2R-FoQ"/>
                         <viewControllerLayoutGuide type="bottom" id="xzu-VI-sNV"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="PaL-Mo-bUW" customClass="View">
+                    <view key="view" contentMode="scaleToFill" id="PaL-Mo-bUW">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>

--- a/Swift/KVSiOSApp/SignalingClient.swift
+++ b/Swift/KVSiOSApp/SignalingClient.swift
@@ -104,6 +104,11 @@ extension SignalingClient: WebSocketDelegate {
     }
 
     func websocketDidReceiveMessage(socket _: WebSocketClient, text: String) {
+        guard !text.isEmpty else {
+            debugPrint("Ignoring empty WebSocket message")
+            return
+        }
+
         debugPrint("Additional signaling messages \(text)")
         var parsedMessage: Message?
 

--- a/Swift/KVSiOSApp/VideoViewController.swift
+++ b/Swift/KVSiOSApp/VideoViewController.swift
@@ -125,9 +125,9 @@ class VideoViewController: UIViewController {
         let tenMinutesAgo = Date().addingTimeInterval(-600)
         storageSessionAttempts = storageSessionAttempts.filter { $0 > tenMinutesAgo }
         
-        // Check if we've exceeded 2 attempts in the last 10 minutes
-        if storageSessionAttempts.count >= 2 {
-            print("Too many storage session attempts (5) within 10 minutes. Stopping retries.")
+        // Check if we've exceeded 3 attempts in the last 10 minutes
+        if storageSessionAttempts.count >= 3 {
+            print("Too many storage session attempts (3) within 10 minutes. Stopping retries.")
             return
         }
         

--- a/Swift/KVSiOSApp/VideoViewController.swift
+++ b/Swift/KVSiOSApp/VideoViewController.swift
@@ -1,22 +1,28 @@
 import UIKit
 import AWSKinesisVideo
+import AWSKinesisVideoWebRTCStorage
 import WebRTC
 
 class VideoViewController: UIViewController {
     @IBOutlet var localVideoView: UIView?
-    @IBOutlet var joinStorageButton: UIButton?
     
     private let webRTCClient: WebRTCClient
     private let signalingClient: SignalingClient
     private let localSenderClientID: String
     private let isMaster: Bool
+    private let signalingChannelArn: String?
+    private var hasReceivedOffer = false
+    private var storageSessionAttempts: [Date] = []
 
-    init(webRTCClient: WebRTCClient, signalingClient: SignalingClient, localSenderClientID: String, isMaster: Bool, mediaServerEndPoint: String?) {
+    init(webRTCClient: WebRTCClient, signalingClient: SignalingClient, localSenderClientID: String, isMaster: Bool, signalingChannelArn: String?) {
         self.webRTCClient = webRTCClient
         self.signalingClient = signalingClient
         self.localSenderClientID = localSenderClientID
         self.isMaster = isMaster
+        self.signalingChannelArn = signalingChannelArn
         super.init(nibName: String(describing: VideoViewController.self), bundle: Bundle.main)
+        
+        let isIngestMedia: Bool = self.signalingChannelArn != nil
         
         if !isMaster {
             // In viewer mode send offer once connection is established
@@ -24,8 +30,11 @@ class VideoViewController: UIViewController {
                 self.signalingClient.sendOffer(rtcSdp: sdp, senderClientid: self.localSenderClientID)
             }
         }
-        if mediaServerEndPoint == nil {
-            self.joinStorageButton?.isHidden = true
+
+        if isIngestMedia {
+            DispatchQueue.global(qos: .background).async {
+                self.joinStorageSessionWithRetry()
+            }
         }
     }
     
@@ -40,26 +49,33 @@ class VideoViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        let isIngestMode = signalingChannelArn != nil
+        
         #if arch(arm64)
         // Using metal (arm64 only)
-        let localRenderer = RTCMTLVideoView(frame: localVideoView?.frame ?? CGRect.zero)
+        let localRenderer = RTCMTLVideoView(frame: isIngestMode ? view.frame : (localVideoView?.frame ?? CGRect.zero))
         let remoteRenderer = RTCMTLVideoView(frame: view.frame)
         localRenderer.videoContentMode = .scaleAspectFill
         remoteRenderer.videoContentMode = .scaleAspectFill
         #else
         // Using OpenGLES for the rest
-        let localRenderer = RTCEAGLVideoView(frame: localVideoView?.frame ?? CGRect.zero)
+        let localRenderer = RTCEAGLVideoView(frame: isIngestMode ? view.frame : (localVideoView?.frame ?? CGRect.zero))
         let remoteRenderer = RTCEAGLVideoView(frame: view.frame)
         #endif
 
         webRTCClient.startCaptureLocalVideo(renderer: localRenderer)
-        webRTCClient.renderRemoteVideo(to: remoteRenderer)
-
-        if let localVideoView = self.localVideoView {
-            embedView(localRenderer, into: localVideoView)
+        
+        if isIngestMode {
+            embedView(localRenderer, into: view)
+            view.sendSubview(toBack: localRenderer)
+        } else {
+            webRTCClient.renderRemoteVideo(to: remoteRenderer)
+            if let localVideoView = self.localVideoView {
+                embedView(localRenderer, into: localVideoView)
+            }
+            embedView(remoteRenderer, into: view)
+            view.sendSubview(toBack: remoteRenderer)
         }
-        embedView(remoteRenderer, into: view)
-        view.sendSubview(toBack: remoteRenderer)
     }
 
     private func embedView(_ view: UIView, into containerView: UIView) {
@@ -83,10 +99,53 @@ class VideoViewController: UIViewController {
         dismiss(animated: true)
     }
     
-    @IBAction func joinStorageSession(_: Any) {
-        print("button pressed")
-        joinStorageButton?.isHidden = true
+    func joinStorageSessionWithRetry() {
+        guard let signalingChannelArn = self.signalingChannelArn else {
+            print("joinStorageSessionWithRetry IllegalState! ARN cannot be nil")
+            return
+        }
         
+        // If we already received an offer, stop retrying
+        if hasReceivedOffer {
+            print("SDP offer received, stopping storage session retries")
+            return
+        }
+        
+        // Clean up attempts older than 10 minutes
+        let tenMinutesAgo = Date().addingTimeInterval(-600)
+        storageSessionAttempts = storageSessionAttempts.filter { $0 > tenMinutesAgo }
+        
+        // Check if we've exceeded 5 attempts in the last 10 minutes
+        if storageSessionAttempts.count >= 5 {
+            print("Too many storage session attempts (5) within 10 minutes. Stopping retries.")
+            return
+        }
+        
+        // Record this attempt
+        storageSessionAttempts.append(Date())
+        
+        let webrtcStorageClient = AWSKinesisVideoWebRTCStorage(forKey: awsKinesisVideoKey)
+        let joinStorageSessionRequest = AWSKinesisVideoWebRTCStorageJoinStorageSessionInput()
+        joinStorageSessionRequest?.channelArn = signalingChannelArn
+        
+        print("Calling JoinStorageSession with ARN: \(signalingChannelArn) (attempt \(storageSessionAttempts.count))")
+
+        webrtcStorageClient.joinSession(joinStorageSessionRequest!).continueWith(block: { (task) -> Void in
+            if let error = task.error {
+                print("Error joining storage session: \(error)")
+            } else {
+                print("Joined storage session!")
+            }
+            
+            // Retry after 6 seconds if no offer received yet
+            DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 6.0) {
+                self.joinStorageSessionWithRetry()
+            }
+        })
+    }
+    
+    func markOfferReceived() {
+        hasReceivedOffer = true
     }
 
     func sendAnswer(recipientClientID: String) {
@@ -94,6 +153,54 @@ class VideoViewController: UIViewController {
             self.signalingClient.sendAnswer(rtcSdp: localSdp, recipientClientId: recipientClientID)
             print("Sent answer. Update peer connection map and handle pending ice candidates")
             self.webRTCClient.updatePeerConnectionAndHandleIceCandidates(clientId: recipientClientID)
+        }
+    }
+    
+    func showToast(message: String, length: String = "short") {
+        guard length == "short" || length == "long" else {
+            print("showToast: Invalid argument - length must either be short or long")
+            return
+        }
+        
+        let durationSec = length == "short" ? 2.0 : 3.5
+        let padding: CGFloat = 12
+        
+        let toastContainer = UIView()
+        toastContainer.backgroundColor = UIColor.black.withAlphaComponent(0.8)
+        toastContainer.layer.cornerRadius = 10
+        toastContainer.translatesAutoresizingMaskIntoConstraints = false
+        toastContainer.alpha = 0.0
+        
+        let toastLabel = UILabel()
+        toastLabel.text = message
+        toastLabel.textAlignment = .center
+        toastLabel.textColor = UIColor.white
+        toastLabel.font = UIFont.systemFont(ofSize: 14)
+        toastLabel.numberOfLines = 0
+        toastLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        toastContainer.addSubview(toastLabel)
+        self.view.addSubview(toastContainer)
+        
+        NSLayoutConstraint.activate([
+            toastLabel.topAnchor.constraint(equalTo: toastContainer.topAnchor, constant: padding),
+            toastLabel.bottomAnchor.constraint(equalTo: toastContainer.bottomAnchor, constant: -padding),
+            toastLabel.leadingAnchor.constraint(equalTo: toastContainer.leadingAnchor, constant: padding),
+            toastLabel.trailingAnchor.constraint(equalTo: toastContainer.trailingAnchor, constant: -padding),
+            toastContainer.leadingAnchor.constraint(greaterThanOrEqualTo: self.view.leadingAnchor, constant: 20),
+            toastContainer.trailingAnchor.constraint(lessThanOrEqualTo: self.view.trailingAnchor, constant: -20),
+            toastContainer.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            toastContainer.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -50)
+        ])
+
+        UIView.animate(withDuration: 0.5, delay: 0, options: .curveEaseOut, animations: {
+            toastContainer.alpha = 1.0
+        }) { _ in
+            UIView.animate(withDuration: 0.5, delay: durationSec, options: .curveEaseIn, animations: {
+                toastContainer.alpha = 0.0
+            }) { _ in
+                toastContainer.removeFromSuperview()
+            }
         }
     }
 }

--- a/Swift/KVSiOSApp/VideoViewController.swift
+++ b/Swift/KVSiOSApp/VideoViewController.swift
@@ -13,7 +13,7 @@ class VideoViewController: UIViewController {
     private let signalingChannelArn: String?
     private let isVideoEnabled: Bool
     private var hasReceivedOffer = false
-    private var storageSessionAttempts: [Date]
+    private var storageSessionConnectionAttempts: [Date]
 
     init(webRTCClient: WebRTCClient, signalingClient: SignalingClient, localSenderClientID: String, isMaster: Bool, signalingChannelArn: String?, isVideoEnabled: Bool = true) {
         self.webRTCClient = webRTCClient
@@ -22,21 +22,21 @@ class VideoViewController: UIViewController {
         self.isMaster = isMaster
         self.signalingChannelArn = signalingChannelArn
         self.isVideoEnabled = isVideoEnabled
-        self.storageSessionAttempts = []
+        self.storageSessionConnectionAttempts = []
         super.init(nibName: String(describing: VideoViewController.self), bundle: Bundle.main)
         
-        let isIngestMedia: Bool = self.signalingChannelArn != nil
-        print("isIngestMedia? \(isIngestMedia)")
+        let isStorageSession: Bool = self.signalingChannelArn != nil
+        print("isStorageSession? \(isStorageSession)")
         print("role: \(isMaster ? "master" : "viewer")")
         
-        if !isIngestMedia && !isMaster {
+        if !isStorageSession && !isMaster {
             // In viewer mode send offer once connection is established
             webRTCClient.offer { sdp in
                 self.signalingClient.sendOffer(rtcSdp: sdp, senderClientid: self.localSenderClientID)
             }
         }
 
-        if isIngestMedia {
+        if isStorageSession {
             DispatchQueue.global(qos: .background).async {
                 self.joinStorageSessionWithRetry()
             }
@@ -129,16 +129,16 @@ class VideoViewController: UIViewController {
         
         // Clean up attempts older than 10 minutes
         let tenMinutesAgo = Date().addingTimeInterval(-600)
-        storageSessionAttempts = storageSessionAttempts.filter { $0 > tenMinutesAgo }
+        storageSessionConnectionAttempts = storageSessionConnectionAttempts.filter { $0 > tenMinutesAgo }
         
         // Check if we've exceeded 3 attempts in the last 10 minutes
-        if storageSessionAttempts.count >= 3 {
+        if storageSessionConnectionAttempts.count >= 3 {
             print("Too many storage session attempts (3) within 10 minutes. Stopping retries.")
             return
         }
         
         // Record this attempt
-        storageSessionAttempts.append(Date())
+        storageSessionConnectionAttempts.append(Date())
         
         let webrtcStorageClient = AWSKinesisVideoWebRTCStorage(forKey: awsKinesisVideoKey)
 
@@ -146,7 +146,7 @@ class VideoViewController: UIViewController {
             let joinStorageSessionRequest = AWSKinesisVideoWebRTCStorageJoinStorageSessionInput()
             joinStorageSessionRequest?.channelArn = signalingChannelArn
             
-            print("Calling JoinStorageSession with ARN: \(signalingChannelArn) (attempt \(storageSessionAttempts.count))")
+            print("Calling JoinStorageSession with ARN: \(signalingChannelArn) (attempt \(storageSessionConnectionAttempts.count))")
 
             webrtcStorageClient.joinSession(joinStorageSessionRequest!).continueWith(block: { (task) -> Void in
                 if let error = task.error {
@@ -165,7 +165,7 @@ class VideoViewController: UIViewController {
             joinStorageSessionAsViewerRequest?.channelArn = signalingChannelArn
             joinStorageSessionAsViewerRequest?.clientId = self.localSenderClientID
 
-            print("Calling JoinStorageSessionAsViewer with ARN: \(signalingChannelArn) and clientId: \(self.localSenderClientID) (attempt \(storageSessionAttempts.count))")
+            print("Calling JoinStorageSessionAsViewer with ARN: \(signalingChannelArn) and clientId: \(self.localSenderClientID) (attempt \(storageSessionConnectionAttempts.count))")
             
             webrtcStorageClient.joinSession(asViewer: joinStorageSessionAsViewerRequest!).continueWith(block: { (task) -> Void in
                 if let error = task.error {

--- a/Swift/KVSiOSApp/VideoViewController.xib
+++ b/Swift/KVSiOSApp/VideoViewController.xib
@@ -1,23 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="ipad12_9" orientation="portrait" layout="fullscreen" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24127" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="VideoViewController" customModule="AWSKinesisVideoWebRTCDemoApp" customModuleProvider="target">
             <connections>
-                <outlet property="joinStorageButton" destination="EEy-nz-bbj" id="4aX-HB-OFa"/>
                 <outlet property="localVideoView" destination="AOt-yj-kPb" id="Dck-BK-47J"/>
                 <outlet property="view" destination="iN0-l3-epB" id="t0K-uJ-o5K"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
+            <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N0c-WK-c8E">
@@ -29,18 +28,9 @@
                     </connections>
                 </button>
                 <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AOt-yj-kPb" userLabel="LocalView">
-                    <rect key="frame" x="231.5" y="480.5" width="772.5" height="865.5"/>
+                    <rect key="frame" x="231.66666666666663" y="480.66666666666674" width="141.33333333333337" height="351.33333333333326"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="EEy-nz-bbj">
-                    <rect key="frame" x="0.0" y="58" width="120" height="35"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <state key="normal" title="Button"/>
-                    <buttonConfiguration key="configuration" style="plain" title="Join Session"/>
-                    <connections>
-                        <action selector="joinStorageSession:" destination="-1" eventType="touchUpInside" id="iOt-88-doA"/>
-                    </connections>
-                </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="CYb-ul-ZkI"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Swift/KVSiOSApp/WebRTCClient.swift
+++ b/Swift/KVSiOSApp/WebRTCClient.swift
@@ -146,8 +146,10 @@ final class WebRTCClient: NSObject {
         peerConnection.setRemoteDescription(remoteSdp, completionHandler: completion)
         if remoteSdp.type == RTCSdpType.answer {
             print("Received answer for client ID: \(clientId)")
-            updatePeerConnectionAndHandleIceCandidates(clientId: clientId)
+        } else {
+            print("Received offer from remote")
         }
+        updatePeerConnectionAndHandleIceCandidates(clientId: clientId)
     }
 
     func checkAndAddIceCandidate(remoteCandidate: RTCIceCandidate, clientId: String) {

--- a/Swift/KVSiOSApp/WebRTCClient.swift
+++ b/Swift/KVSiOSApp/WebRTCClient.swift
@@ -30,11 +30,12 @@ final class WebRTCClient: NSObject {
     private var remoteDataChannel: RTCDataChannel?
     private var constructedIceServers: [RTCIceServer]?
     private var selectedResolution: VideoResolution
+    private var remoteRenderer: RTCVideoRenderer?
 
     private var peerConnectionFoundMap = [String: RTCPeerConnection]()
     private var pendingIceCandidatesMap = [String: Set<RTCIceCandidate>]()
 
-    required init(iceServers: [RTCIceServer], isAudioOn: Bool, resolution: VideoResolution = .resolution720p) {
+    required init(iceServers: [RTCIceServer], isAudioOn: Bool, isVideoOn: Bool = true, resolution: VideoResolution = .resolution720p) {
         self.selectedResolution = resolution
 
         let config = RTCConfiguration()
@@ -55,7 +56,9 @@ final class WebRTCClient: NSObject {
         if (isAudioOn) {
         createLocalAudioStream()
         }
+        if (isVideoOn) {
         createLocalVideoStream()
+        }
         peerConnection.delegate = self
     }
 
@@ -219,7 +222,17 @@ final class WebRTCClient: NSObject {
     }
 
     func renderRemoteVideo(to renderer: RTCVideoRenderer) {
+        debugPrint("renderRemoteVideo called, remoteVideoTrack: \(remoteVideoTrack != nil)")
+        remoteRenderer = renderer
         remoteVideoTrack?.add(renderer)
+    }
+
+    func enableVideo(_ enabled: Bool) {
+        localVideoTrack?.isEnabled = enabled
+    }
+
+    func enableAudio(_ enabled: Bool) {
+        localAudioTrack?.isEnabled = enabled
     }
 
     private func createLocalVideoStream() {
@@ -227,9 +240,7 @@ final class WebRTCClient: NSObject {
 
         if let localVideoTrack = localVideoTrack {
             peerConnection.add(localVideoTrack, streamIds: [streamId])
-            remoteVideoTrack = peerConnection.transceivers.first { $0.mediaType == .video }?.receiver.track as? RTCVideoTrack
         }
-
     }
 
     private func createLocalAudioStream() {
@@ -266,6 +277,19 @@ extension WebRTCClient: RTCPeerConnectionDelegate {
 
     func peerConnection(_: RTCPeerConnection, didRemove stream: RTCMediaStream) {
         debugPrint("peerConnection didRemove stream:\(stream)")
+    }
+
+    func peerConnection(_ peerConnection: RTCPeerConnection, didAdd rtpReceiver: RTCRtpReceiver, streams mediaStreams: [RTCMediaStream]) {
+        debugPrint("peerConnection didAdd rtpReceiver: \(rtpReceiver.track?.kind ?? "unknown")")
+        if rtpReceiver.track?.kind == kRTCMediaStreamTrackKindVideo {
+            remoteVideoTrack = rtpReceiver.track as? RTCVideoTrack
+            debugPrint("Remote video track assigned: \(remoteVideoTrack != nil)")
+            // Add to renderer if we have one stored
+            if let renderer = remoteRenderer {
+                remoteVideoTrack?.add(renderer)
+                debugPrint("Added remote video track to renderer")
+            }
+        }
     }
 
     func peerConnectionShouldNegotiate(_: RTCPeerConnection) {

--- a/Swift/Podfile
+++ b/Swift/Podfile
@@ -9,6 +9,7 @@ target 'AWSKinesisVideoWebRTCDemoApp' do
   pod 'CommonCryptoModule'
   pod 'AWSKinesisVideo'
   pod 'AWSKinesisVideoSignaling'
+  pod 'AWSKinesisVideoWebRTCStorage'
   pod 'GoogleWebRTC', '~> 1.1'
   pod 'Starscream', '~> 3.0'
   	target 'AWSKinesisVideoWebRTCDemoAppUITests' do


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Implemented storage session support for master and viewer participants
  - "Send video" switch & UI
  - Error pop-ups for invalid audio+video configurations (video+audio required for ingestion master participant; audio-only or no audio and no video for viewer participants)
- Added additional enhancements to overall sample app experience including:
  - Implemented toast pop-ups for important RTCPeerConnection state changes (connected/failed/disconnected)
  - Fixed the "send audio" switch label to be properly shown on the configuration screen
  - Removed the remote-video view in ingestion mode master participant mode
  - Removed the self-video view in ingestion mode viewer participant mode
- Fixed the pending ice candidates queue logic to allow for ICE candidates to be properly added to the PeerConnection before the offer is received. 

*Why was it changed?*
- Support for [KVS WebRTC ingestion](https://docs.aws.amazon.com/kinesisvideostreams-webrtc-dg/latest/devguide/webrtc-ingestion.html)
- The demo app provides demonstrates connecting to the storage session and sending the media for ingestion & storage

*How was it changed?*
- Imported AWSKinesisVideoWebRTCStorage client to be able to call JoinStorageSession and JoinStorageSessionAsViewer to have the storage session initiate the WebRTC connection
- Added UI validation to restrict ingestion viewers from using video with ingest media (audio-only restriction)
- Updated video track creation logic to conditionally create video track based on user selection
- Adjusted viewer logic to wait for offers from storage session and respond with an answer, instead of creating their own offers (switch the logic from controlling peer to controlled peer)
- Adjust the UI to hide the unused views in the ingestion mode (self-view in viewer mode, remote view in master mode)

*What testing was done for the changes?*
- Tested peer-to-peer connection with the JS chrome (iOS master & iOS viewer)
  - In audio-only mode, video+audio mode, and video-only mode
- Tested WebRTC ingestion
  - iOS Master participant + Chrome viewer participant
  - Chrome Master participant + iOS viewer participant
- Checked that the toasts show up appropriately

| Connected | Disconnected |
|------------|---------------|
|  <img width="329" height="548" alt="image" src="https://github.com/user-attachments/assets/c41adab8-47ea-4eee-806e-972be204b939" />  |   <img width="391" height="567" alt="image" src="https://github.com/user-attachments/assets/36854a68-cb54-427e-b304-e3da806eb1f0" />  |



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
