### PR TITLE
Release 1.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - master
+      - develop
   pull_request:
     branches:
       - master
+      - develop
 jobs:
   build-sample-app:
     strategy:

--- a/Swift/AWSKinesisVideoWebRTCDemoApp.xcodeproj/project.pbxproj
+++ b/Swift/AWSKinesisVideoWebRTCDemoApp.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 					17FC2F7B1E258FC500174015 = {
 						CreatedOnToolsVersion = 7.3.1;
 						LastSwiftMigration = 1020;
+						ProvisioningStyle = Automatic;
 					};
 					703513E32399DA0400376B66 = {
 						CreatedOnToolsVersion = 11.2;
@@ -469,6 +470,7 @@
 				"${BUILT_PRODUCTS_DIR}/AWSCore/AWSCore.framework",
 				"${BUILT_PRODUCTS_DIR}/AWSKinesisVideo/AWSKinesisVideo.framework",
 				"${BUILT_PRODUCTS_DIR}/AWSKinesisVideoSignaling/AWSKinesisVideoSignaling.framework",
+				"${BUILT_PRODUCTS_DIR}/AWSKinesisVideoWebRTCStorage/AWSKinesisVideoWebRTCStorage.framework",
 				"${BUILT_PRODUCTS_DIR}/AWSMobileClient/AWSMobileClient.framework",
 				"${BUILT_PRODUCTS_DIR}/CommonCryptoModule/CommonCryptoModule.framework",
 				"${PODS_ROOT}/GoogleWebRTC/Frameworks/frameworks/WebRTC.framework",
@@ -482,6 +484,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSKinesisVideo.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSKinesisVideoSignaling.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSKinesisVideoWebRTCStorage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSMobileClient.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CommonCryptoModule.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WebRTC.framework",
@@ -527,6 +530,7 @@
 				"${BUILT_PRODUCTS_DIR}/AWSCore/AWSCore.framework",
 				"${BUILT_PRODUCTS_DIR}/AWSKinesisVideo/AWSKinesisVideo.framework",
 				"${BUILT_PRODUCTS_DIR}/AWSKinesisVideoSignaling/AWSKinesisVideoSignaling.framework",
+				"${BUILT_PRODUCTS_DIR}/AWSKinesisVideoWebRTCStorage/AWSKinesisVideoWebRTCStorage.framework",
 				"${BUILT_PRODUCTS_DIR}/AWSMobileClient/AWSMobileClient.framework",
 				"${BUILT_PRODUCTS_DIR}/CommonCryptoModule/CommonCryptoModule.framework",
 				"${PODS_ROOT}/GoogleWebRTC/Frameworks/frameworks/WebRTC.framework",
@@ -540,6 +544,7 @@
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSCore.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSKinesisVideo.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSKinesisVideoSignaling.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSKinesisVideoWebRTCStorage.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AWSMobileClient.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CommonCryptoModule.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WebRTC.framework",
@@ -659,8 +664,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
-				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -723,8 +728,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
-				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				"ARCHS[sdk=iphoneos*]" = "$(ARCHS_STANDARD)";
+				"ARCHS[sdk=iphonesimulator*]" = x86_64;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -784,6 +789,8 @@
 			baseConfigurationReference = BDB1499CD0982C181C7DDE9E /* Pods-AWSKinesisVideoWebRTCDemoApp.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=*]" = "";
@@ -825,6 +832,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.kinesisvideo.KVSApp1;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;

--- a/Swift/AWSKinesisVideoWebRTCDemoAppTests/VideoViewControllerTests.swift
+++ b/Swift/AWSKinesisVideoWebRTCDemoAppTests/VideoViewControllerTests.swift
@@ -20,9 +20,9 @@ class VideoViewControllerTests: XCTestCase{
         signalingClient!.connect()
         
         RTCIceServersList.append(RTCIceServer.init(urlStrings: ["stun:stun.kinesisvideo." + "us-west-2" + ".amazonaws.com:443"]))
-        webRTCClient = WebRTCClient(iceServers: RTCIceServersList, isAudioOn: true)
+        webRTCClient = WebRTCClient(iceServers: RTCIceServersList, isAudioOn: true, isVideoOn: true)
         webRTCClient!.delegate = channelVC
-        videoViewController = VideoViewController(webRTCClient: self.webRTCClient!, signalingClient: self.signalingClient!, localSenderClientID: "randomClientID", isMaster: true, mediaServerEndPoint: nil)
+        videoViewController = VideoViewController(webRTCClient: self.webRTCClient!, signalingClient: self.signalingClient!, localSenderClientID: "randomClientID", isMaster: true, signalingChannelArn: nil)
     }
     
     override func tearDown() {

--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -2,6 +2,7 @@ import AWSCore
 import AWSCognitoIdentityProvider
 import AWSKinesisVideo
 import AWSKinesisVideoSignaling
+import AWSKinesisVideoWebRTCStorage
 import AWSMobileClient
 import Foundation
 import WebRTC
@@ -32,6 +33,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
 
     // variables controlled by UI
     var sendAudioEnabled: Bool = true
+    var sendVideoEnabled: Bool = true
     var isMaster: Bool = false
     var signalingConnected: Bool = false
     var selectedResolution: VideoResolution = .resolution720p
@@ -52,6 +54,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
     @IBOutlet var clientID: UITextField!
     @IBOutlet var regionName: UITextField!
     @IBOutlet var isAudioEnabled: UISwitch!
+    @IBOutlet var isVideoEnabled: UISwitch!
     @IBOutlet var resolutionButton: UIButton!
 
     // Connect Buttons
@@ -115,6 +118,14 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
             self.sendAudioEnabled = true
         } else {
             self.sendAudioEnabled = false
+        }
+    }
+
+    @IBAction func videoStateChanged(sender: UISwitch!) {
+        if sender.isOn {
+            self.sendVideoEnabled = true
+        } else {
+            self.sendVideoEnabled = false
         }
     }
 
@@ -224,18 +235,24 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
             }
         }
         // check whether signalling channel will save its recording to a stream
-        // only applies for master
-        var usingMediaServer : Bool = false
-        if self.isMaster {
-            usingMediaServer = isUsingMediaServer(channelARN: channelARN!, channelName: channelNameValue)
-            // Make sure that audio is enabled if ingesting webrtc connection
-            if(usingMediaServer && !self.sendAudioEnabled) {
-                popUpError(title: "Invalid Configuration", message: "Audio must be enabled to use MediaServer")
+        var useStorageSession: Bool = isUsingStorageSession(channelARN: channelARN!, channelName: channelNameValue)
+        // Make sure that audio is enabled if ingesting webrtc connection
+        if (useStorageSession) {
+            if (self.isMaster && (!self.isAudioEnabled.isOn || !self.isVideoEnabled.isOn)) {
+                // Master mode: Both audio and video required
+                popUpError(title: "Invalid Configuration", message: "Video and audio must be enabled for WebRTC ingestion master")
                 return
+            } else if (!self.isMaster) {
+                // Viewer mode: Video not allowed, audio optional
+                if (self.isVideoEnabled.isOn) {
+                    popUpError(title: "Invalid Configuration", message: "Video is not allowed for WebRTC ingestion viewer")
+                    return
+                }
             }
         }
+
         // get signalling channel endpoints
-        let endpoints = getSignallingEndpoints(channelARN: channelARN!, region: awsRegionValue, isMaster: self.isMaster, useMediaServer: usingMediaServer)
+        let endpoints = getSignallingEndpoints(channelARN: channelARN!, region: awsRegionValue, isMaster: self.isMaster, useStorageSession: useStorageSession)
         //// Ensure that the WebSocket (WSS) endpoint is available; WebRTC requires a valid signaling endpoint.
         if endpoints["WSS"] == nil {
             popUpError(title: "Invalid SignallingEndpoints", message: "SignallingEndpoints is required for WebRTC connection")
@@ -254,8 +271,20 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
                         service: .KinesisVideo,
                         url: URL(string: endpoints["HTTPS"]!!))
         let RTCIceServersList = getIceCandidates(channelARN: channelARN!, endpoint: httpsEndpoint!, regionType: awsRegionType, clientId: localSenderId)
-        webRTCClient = WebRTCClient(iceServers: RTCIceServersList, isAudioOn: sendAudioEnabled, resolution: selectedResolution)
+        webRTCClient = WebRTCClient(iceServers: RTCIceServersList, isAudioOn: sendAudioEnabled, isVideoOn: sendVideoEnabled, resolution: selectedResolution)
         webRTCClient!.delegate = self
+        
+        guard !useStorageSession || endpoints["WEBRTC"] != nil else {
+            print("connectAsRole IllegalState! WEBRTC endpoint is required for WebRTC ingestion")
+            return
+        }
+        if useStorageSession {
+            let webRTCEndpoint: String = endpoints["WEBRTC"]!!
+            let webRTCStorageConfiguration = AWSServiceConfiguration(region: awsRegionType,
+                                                                    endpoint: AWSEndpoint(urlString: webRTCEndpoint),
+                                                                    credentialsProvider: getCredentialsProvider())
+            AWSKinesisVideoWebRTCStorage.register(with: webRTCStorageConfiguration!, forKey: awsKinesisVideoKey)
+        }
 
         // Connect to signalling channel with wss endpoint
         print("Connecting to web socket from channel config")
@@ -267,7 +296,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         let seconds = 2.0
         DispatchQueue.main.asyncAfter(deadline: .now() + seconds) {
             self.updateConnectionLabel()
-            self.vc = VideoViewController(webRTCClient: self.webRTCClient!, signalingClient: self.signalingClient!, localSenderClientID: self.localSenderId, isMaster: self.isMaster, mediaServerEndPoint: endpoints["WEBRTC"] ?? nil)
+            self.vc = VideoViewController(webRTCClient: self.webRTCClient!, signalingClient: self.signalingClient!, localSenderClientID: self.localSenderId, isMaster: self.isMaster, signalingChannelArn: useStorageSession ? channelARN : nil, isVideoEnabled: self.sendVideoEnabled)
             self.present(self.vc!, animated: true, completion: nil)
         }
     }
@@ -327,8 +356,8 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         return channelARN
     }
     
-    // check media server is enabled for signalling channel
-    func isUsingMediaServer(channelARN: String, channelName: String) -> Bool {
+    // check storage session (WebRTC ingestion) is enabled for signalling channel
+    func isUsingStorageSession(channelARN: String, channelName: String) -> Bool {
         var usingMediaServer : Bool = false
         /*
             equivalent AWS CLI command:
@@ -348,6 +377,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
                 }
             }
         }).waitUntilFinished()
+        print("\(channelARN) configured for ingestion? \(usingMediaServer)")
         return usingMediaServer
     }
     
@@ -388,7 +418,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
     }
    
     // Get signalling endpoints for the given signalling channel ARN 
-    func getSignallingEndpoints(channelARN: String, region: String, isMaster: Bool, useMediaServer: Bool) -> Dictionary<String, String?> {
+    func getSignallingEndpoints(channelARN: String, region: String, isMaster: Bool, useStorageSession: Bool) -> Dictionary<String, String?> {
         
         var endpoints = Dictionary <String, String?>()
         /*
@@ -400,7 +430,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         singleMasterChannelEndpointConfiguration?.protocols = videoProtocols
         singleMasterChannelEndpointConfiguration?.role = getSingleMasterChannelEndpointRole(isMaster: isMaster)
         
-        if(useMediaServer){
+        if (useStorageSession){
             singleMasterChannelEndpointConfiguration?.protocols?.append("WEBRTC")
         }
  
@@ -499,6 +529,12 @@ extension ChannelConfigurationViewController: SignalClientDelegate {
             remoteSenderClientId = senderClientId
         }
         setRemoteSenderClientId()
+        
+        // Mark that offer was received to stop storage session retries
+        if sdp.type == .offer {
+            vc?.markOfferReceived()
+        }
+        
         webRTCClient!.set(remoteSdp: sdp, clientId: senderClientId) { _ in
             print("Setting remote sdp and sending answer.")
             self.vc!.sendAnswer(recipientClientID: self.remoteSenderClientId!)
@@ -529,14 +565,23 @@ extension ChannelConfigurationViewController: WebRTCClientDelegate {
         switch state {
         case .connected, .completed:
             print("WebRTC connected/completed state")
+            DispatchQueue.main.async {
+                self.vc?.showToast(message: "WebRTC Connected", length: "short")
+            }
         case .disconnected:
             print("WebRTC disconnected state")
+            DispatchQueue.main.async {
+                self.vc?.showToast(message: "WebRTC Disconnected", length: "short")
+            }
+        case .failed:
+            print("WebRTC failed state")
+            DispatchQueue.main.async {
+                self.vc?.showToast(message: "WebRTC Connection Failed", length: "long")
+            }
         case .new:
             print("WebRTC new state")
         case .checking:
             print("WebRTC checking state")
-        case .failed:
-            print("WebRTC failed state")
         case .closed:
             print("WebRTC closed state")
         case .count:

--- a/Swift/KVSiOSApp/Constants.swift
+++ b/Swift/KVSiOSApp/Constants.swift
@@ -12,7 +12,7 @@ let cognitoIdentityPoolId = "REPLACEME"
 
 // App constants
 let appName = "aws-kvs-webrtc-ios-client"
-let appVersion = "1.0.0"
+let appVersion = "1.1.0"
 
 // KinesisVideo constants
 let awsKinesisVideoKey = "kinesisvideo"

--- a/Swift/KVSiOSApp/Main.storyboard
+++ b/Swift/KVSiOSApp/Main.storyboard
@@ -552,12 +552,12 @@
                         <viewControllerLayoutGuide type="top" id="719-2R-FoQ"/>
                         <viewControllerLayoutGuide type="bottom" id="xzu-VI-sNV"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="PaL-Mo-bUW" customClass="zz">
+                    <view key="view" contentMode="scaleToFill" id="PaL-Mo-bUW">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="43" translatesAutoresizingMaskIntoConstraints="NO" id="4pf-3f-52M">
-                                <rect key="frame" x="66" y="104" width="243" height="425.5"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="4pf-3f-52M">
+                                <rect key="frame" x="66" y="74" width="243" height="564.5"/>
                                 <subviews>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Channel Name " textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zEP-tC-ik7">
                                         <rect key="frame" x="0.0" y="0.0" width="243" height="25"/>
@@ -569,7 +569,7 @@
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Client ID (optional)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="a2V-fh-lBx">
-                                        <rect key="frame" x="0.0" y="68" width="243" height="25"/>
+                                        <rect key="frame" x="0.0" y="65" width="243" height="25"/>
                                         <accessibility key="accessibilityConfiguration" identifier="clientidtextfield"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="25" id="drp-Hv-OMz"/>
@@ -578,7 +578,7 @@
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Region" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nr9-tN-CuW">
-                                        <rect key="frame" x="0.0" y="136" width="243" height="25"/>
+                                        <rect key="frame" x="0.0" y="130" width="243" height="25"/>
                                         <accessibility key="accessibilityConfiguration" identifier="regiontextfield"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="25" id="NqF-xK-94H"/>
@@ -587,7 +587,7 @@
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="res-btn-123">
-                                        <rect key="frame" x="0.0" y="204" width="243" height="25"/>
+                                        <rect key="frame" x="0.0" y="195" width="243" height="25"/>
                                         <color key="backgroundColor" systemColor="systemGrayColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="25" id="res-height-123"/>
@@ -601,7 +601,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3k1-42-Mbg">
-                                        <rect key="frame" x="0.0" y="272" width="250" height="25"/>
+                                        <rect key="frame" x="0.0" y="260" width="243" height="25"/>
                                         <color key="backgroundColor" red="0.1960784314" green="0.60392156860000001" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <accessibility key="accessibilityConfiguration" identifier="connectasmasterbutton"/>
                                         <constraints>
@@ -616,7 +616,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KMq-bs-4Hv">
-                                        <rect key="frame" x="0.0" y="272" width="243" height="25"/>
+                                        <rect key="frame" x="0.0" y="325" width="243" height="25"/>
                                         <color key="backgroundColor" red="0.1960784314" green="0.60392156860000001" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <accessibility key="accessibilityConfiguration" identifier="connectasviewerbutton"/>
                                         <constraints>
@@ -630,16 +630,34 @@
                                             <action selector="connectAsViewerWith_sender:" destination="fxY-gB-7Yj" eventType="touchUpInside" id="0T8-1E-4hO"/>
                                         </connections>
                                     </button>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="120" translatesAutoresizingMaskIntoConstraints="NO" id="G8H-J9-l8I">
-                                        <rect key="frame" x="0.0" y="340" width="243" height="28"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="120" translatesAutoresizingMaskIntoConstraints="NO" id="YHE-xZ-R4i">
+                                        <rect key="frame" x="0.0" y="390" width="243" height="52"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Audio" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pV1-OS-ahX">
-                                                <rect key="frame" x="0.0" y="0.0" width="62" height="28"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Send Video" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vLC-Za-qPN">
+                                                <rect key="frame" x="0.0" y="0.0" width="62" height="52"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="11"/>
-                                                <nil key="textColor"/>
+                                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uWn-mC-EnS">
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" title="Is Video Enabled" translatesAutoresizingMaskIntoConstraints="NO" id="Z0n-7n-HzH">
+                                                <rect key="frame" x="182" y="0.0" width="63" height="52"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="audioswitch"/>
+                                                <connections>
+                                                    <action selector="videoStateChangedWithSender:" destination="fxY-gB-7Yj" eventType="valueChanged" id="Vqg-xx-bxL"/>
+                                                </connections>
+                                            </switch>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="120" translatesAutoresizingMaskIntoConstraints="NO" id="G8H-J9-l8I">
+                                        <rect key="frame" x="0.0" y="482" width="243" height="28"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Send Audio" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pV1-OS-ahX">
+                                                <rect key="frame" x="0.0" y="0.0" width="62" height="28"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uWn-mC-EnS">
                                                 <rect key="frame" x="182" y="0.0" width="63" height="28"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="audioswitch"/>
                                                 <connections>
@@ -647,12 +665,9 @@
                                                 </connections>
                                             </switch>
                                         </subviews>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="50" id="H9p-0h-v6z"/>
-                                        </constraints>
                                     </stackView>
                                     <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Not Connected" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="NOw-C6-Bie">
-                                        <rect key="frame" x="0.0" y="411" width="200" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="550" width="243" height="14.5"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -664,7 +679,7 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="4pf-3f-52M" firstAttribute="centerX" secondItem="PaL-Mo-bUW" secondAttribute="centerX" id="NVI-gQ-wnE"/>
-                            <constraint firstItem="4pf-3f-52M" firstAttribute="top" secondItem="719-2R-FoQ" secondAttribute="bottom" constant="30" id="Zez-5g-7f3"/>
+                            <constraint firstItem="4pf-3f-52M" firstAttribute="top" secondItem="719-2R-FoQ" secondAttribute="bottom" id="Zez-5g-7f3"/>
                             <constraint firstItem="4pf-3f-52M" firstAttribute="leading" secondItem="PaL-Mo-bUW" secondAttribute="leadingMargin" constant="50" id="n2h-Cg-NaW"/>
                         </constraints>
                     </view>
@@ -685,6 +700,7 @@
                         <outlet property="connectAsViewerButton" destination="KMq-bs-4Hv" id="HDg-vF-0CB"/>
                         <outlet property="connectedLabel" destination="NOw-C6-Bie" id="cMG-kR-3E9"/>
                         <outlet property="isAudioEnabled" destination="uWn-mC-EnS" id="CUs-sB-mgl"/>
+                        <outlet property="isVideoEnabled" destination="Z0n-7n-HzH" id="q4o-zH-9LY"/>
                         <outlet property="regionName" destination="nr9-tN-CuW" id="tX6-zd-Kpw"/>
                         <outlet property="resolutionButton" destination="res-btn-123" id="res-outlet-123"/>
                     </connections>
@@ -755,8 +771,14 @@
         </scene>
     </scenes>
     <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGrayColor">
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Swift/KVSiOSApp/SignalingClient.swift
+++ b/Swift/KVSiOSApp/SignalingClient.swift
@@ -104,6 +104,11 @@ extension SignalingClient: WebSocketDelegate {
     }
 
     func websocketDidReceiveMessage(socket _: WebSocketClient, text: String) {
+        guard !text.isEmpty else {
+            debugPrint("Ignoring empty WebSocket message")
+            return
+        }
+
         debugPrint("Additional signaling messages \(text)")
         var parsedMessage: Message?
 

--- a/Swift/KVSiOSApp/VideoViewController.swift
+++ b/Swift/KVSiOSApp/VideoViewController.swift
@@ -1,31 +1,45 @@
 import UIKit
 import AWSKinesisVideo
+import AWSKinesisVideoWebRTCStorage
 import WebRTC
 
 class VideoViewController: UIViewController {
     @IBOutlet var localVideoView: UIView?
-    @IBOutlet var joinStorageButton: UIButton?
     
     private let webRTCClient: WebRTCClient
     private let signalingClient: SignalingClient
     private let localSenderClientID: String
     private let isMaster: Bool
+    private let signalingChannelArn: String?
+    private let isVideoEnabled: Bool
+    private var hasReceivedOffer = false
+    private var storageSessionConnectionAttempts: [Date]
 
-    init(webRTCClient: WebRTCClient, signalingClient: SignalingClient, localSenderClientID: String, isMaster: Bool, mediaServerEndPoint: String?) {
+    init(webRTCClient: WebRTCClient, signalingClient: SignalingClient, localSenderClientID: String, isMaster: Bool, signalingChannelArn: String?, isVideoEnabled: Bool = true) {
         self.webRTCClient = webRTCClient
         self.signalingClient = signalingClient
         self.localSenderClientID = localSenderClientID
         self.isMaster = isMaster
+        self.signalingChannelArn = signalingChannelArn
+        self.isVideoEnabled = isVideoEnabled
+        self.storageSessionConnectionAttempts = []
         super.init(nibName: String(describing: VideoViewController.self), bundle: Bundle.main)
         
-        if !isMaster {
+        let isStorageSession: Bool = self.signalingChannelArn != nil
+        print("isStorageSession? \(isStorageSession)")
+        print("role: \(isMaster ? "master" : "viewer")")
+        
+        if !isStorageSession && !isMaster {
             // In viewer mode send offer once connection is established
             webRTCClient.offer { sdp in
                 self.signalingClient.sendOffer(rtcSdp: sdp, senderClientid: self.localSenderClientID)
             }
         }
-        if mediaServerEndPoint == nil {
-            self.joinStorageButton?.isHidden = true
+
+        if isStorageSession {
+            DispatchQueue.global(qos: .background).async {
+                self.joinStorageSessionWithRetry()
+            }
         }
     }
     
@@ -40,26 +54,44 @@ class VideoViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        let isIngestMode = signalingChannelArn != nil
+        
         #if arch(arm64)
-        // Using metal (arm64 only)
         let localRenderer = RTCMTLVideoView(frame: localVideoView?.frame ?? CGRect.zero)
         let remoteRenderer = RTCMTLVideoView(frame: view.frame)
         localRenderer.videoContentMode = .scaleAspectFill
         remoteRenderer.videoContentMode = .scaleAspectFill
         #else
-        // Using OpenGLES for the rest
         let localRenderer = RTCEAGLVideoView(frame: localVideoView?.frame ?? CGRect.zero)
         let remoteRenderer = RTCEAGLVideoView(frame: view.frame)
         #endif
 
-        webRTCClient.startCaptureLocalVideo(renderer: localRenderer)
-        webRTCClient.renderRemoteVideo(to: remoteRenderer)
-
-        if let localVideoView = self.localVideoView {
-            embedView(localRenderer, into: localVideoView)
+        if isIngestMode && isMaster {
+            // Ingestion master: local view only
+            webRTCClient.startCaptureLocalVideo(renderer: localRenderer)
+            embedView(localRenderer, into: view)
+            view.sendSubview(toBack: localRenderer)
+            localVideoView?.isHidden = true
+        } else if isIngestMode && !isMaster {
+            // Ingestion viewer: remote view only
+            webRTCClient.renderRemoteVideo(to: remoteRenderer)
+            embedView(remoteRenderer, into: view)
+            view.sendSubview(toBack: remoteRenderer)
+            localVideoView?.isHidden = true
+        } else {
+            // Non-ingestion: remote fullscreen + local in corner
+            if isVideoEnabled {
+                webRTCClient.startCaptureLocalVideo(renderer: localRenderer)
+                if let localVideoView = self.localVideoView {
+                    embedView(localRenderer, into: localVideoView)
+                }
+            } else {
+                localVideoView?.isHidden = true
+            }
+            webRTCClient.renderRemoteVideo(to: remoteRenderer)
+            embedView(remoteRenderer, into: view)
+            view.sendSubview(toBack: remoteRenderer)
         }
-        embedView(remoteRenderer, into: view)
-        view.sendSubview(toBack: remoteRenderer)
     }
 
     private func embedView(_ view: UIView, into containerView: UIView) {
@@ -83,10 +115,75 @@ class VideoViewController: UIViewController {
         dismiss(animated: true)
     }
     
-    @IBAction func joinStorageSession(_: Any) {
-        print("button pressed")
-        joinStorageButton?.isHidden = true
+    func joinStorageSessionWithRetry() {
+        guard let signalingChannelArn = self.signalingChannelArn else {
+            print("joinStorageSessionWithRetry IllegalState! ARN cannot be nil")
+            return
+        }
         
+        // If we already received an offer, stop retrying
+        if hasReceivedOffer {
+            print("SDP offer received, stopping storage session retries")
+            return
+        }
+        
+        // Clean up attempts older than 10 minutes
+        let tenMinutesAgo = Date().addingTimeInterval(-600)
+        storageSessionConnectionAttempts = storageSessionConnectionAttempts.filter { $0 > tenMinutesAgo }
+        
+        // Check if we've exceeded 3 attempts in the last 10 minutes
+        if storageSessionConnectionAttempts.count >= 3 {
+            print("Too many storage session attempts (3) within 10 minutes. Stopping retries.")
+            return
+        }
+        
+        // Record this attempt
+        storageSessionConnectionAttempts.append(Date())
+        
+        let webrtcStorageClient = AWSKinesisVideoWebRTCStorage(forKey: awsKinesisVideoKey)
+
+        if self.isMaster {
+            let joinStorageSessionRequest = AWSKinesisVideoWebRTCStorageJoinStorageSessionInput()
+            joinStorageSessionRequest?.channelArn = signalingChannelArn
+            
+            print("Calling JoinStorageSession with ARN: \(signalingChannelArn) (attempt \(storageSessionConnectionAttempts.count))")
+
+            webrtcStorageClient.joinSession(joinStorageSessionRequest!).continueWith(block: { (task) -> Void in
+                if let error = task.error {
+                    print("Error joining storage session: \(error)")
+                } else {
+                    print("Joined storage session!")
+                }
+
+                // Retry after 6 seconds if no offer received yet
+                DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 6.0) {
+                    self.joinStorageSessionWithRetry()
+                }
+            })
+        } else {
+            let joinStorageSessionAsViewerRequest = AWSKinesisVideoWebRTCStorageJoinStorageSessionAsViewerInput()
+            joinStorageSessionAsViewerRequest?.channelArn = signalingChannelArn
+            joinStorageSessionAsViewerRequest?.clientId = self.localSenderClientID
+
+            print("Calling JoinStorageSessionAsViewer with ARN: \(signalingChannelArn) and clientId: \(self.localSenderClientID) (attempt \(storageSessionConnectionAttempts.count))")
+            
+            webrtcStorageClient.joinSession(asViewer: joinStorageSessionAsViewerRequest!).continueWith(block: { (task) -> Void in
+                if let error = task.error {
+                    print("Error joining storage session: \(error)")
+                } else {
+                    print("Joined storage session!")
+                }
+
+                // Retry after 6 seconds if no offer received yet
+                DispatchQueue.global(qos: .background).asyncAfter(deadline: .now() + 6.0) {
+                    self.joinStorageSessionWithRetry()
+                }
+            })
+        }
+    }
+    
+    func markOfferReceived() {
+        hasReceivedOffer = true
     }
 
     func sendAnswer(recipientClientID: String) {
@@ -94,6 +191,54 @@ class VideoViewController: UIViewController {
             self.signalingClient.sendAnswer(rtcSdp: localSdp, recipientClientId: recipientClientID)
             print("Sent answer. Update peer connection map and handle pending ice candidates")
             self.webRTCClient.updatePeerConnectionAndHandleIceCandidates(clientId: recipientClientID)
+        }
+    }
+    
+    func showToast(message: String, length: String = "short") {
+        guard length == "short" || length == "long" else {
+            print("showToast: Invalid argument - length must either be short or long")
+            return
+        }
+        
+        let durationSec = length == "short" ? 2.0 : 3.5
+        let padding: CGFloat = 12
+        
+        let toastContainer = UIView()
+        toastContainer.backgroundColor = UIColor.black.withAlphaComponent(0.8)
+        toastContainer.layer.cornerRadius = 10
+        toastContainer.translatesAutoresizingMaskIntoConstraints = false
+        toastContainer.alpha = 0.0
+        
+        let toastLabel = UILabel()
+        toastLabel.text = message
+        toastLabel.textAlignment = .center
+        toastLabel.textColor = UIColor.white
+        toastLabel.font = UIFont.systemFont(ofSize: 14)
+        toastLabel.numberOfLines = 0
+        toastLabel.translatesAutoresizingMaskIntoConstraints = false
+        
+        toastContainer.addSubview(toastLabel)
+        self.view.addSubview(toastContainer)
+        
+        NSLayoutConstraint.activate([
+            toastLabel.topAnchor.constraint(equalTo: toastContainer.topAnchor, constant: padding),
+            toastLabel.bottomAnchor.constraint(equalTo: toastContainer.bottomAnchor, constant: -padding),
+            toastLabel.leadingAnchor.constraint(equalTo: toastContainer.leadingAnchor, constant: padding),
+            toastLabel.trailingAnchor.constraint(equalTo: toastContainer.trailingAnchor, constant: -padding),
+            toastContainer.leadingAnchor.constraint(greaterThanOrEqualTo: self.view.leadingAnchor, constant: 20),
+            toastContainer.trailingAnchor.constraint(lessThanOrEqualTo: self.view.trailingAnchor, constant: -20),
+            toastContainer.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            toastContainer.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor, constant: -50)
+        ])
+
+        UIView.animate(withDuration: 0.5, delay: 0, options: .curveEaseOut, animations: {
+            toastContainer.alpha = 1.0
+        }) { _ in
+            UIView.animate(withDuration: 0.5, delay: durationSec, options: .curveEaseIn, animations: {
+                toastContainer.alpha = 0.0
+            }) { _ in
+                toastContainer.removeFromSuperview()
+            }
         }
     }
 }

--- a/Swift/KVSiOSApp/VideoViewController.xib
+++ b/Swift/KVSiOSApp/VideoViewController.xib
@@ -1,23 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="ipad12_9" orientation="portrait" layout="fullscreen" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24127" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="VideoViewController" customModule="AWSKinesisVideoWebRTCDemoApp" customModuleProvider="target">
             <connections>
-                <outlet property="joinStorageButton" destination="EEy-nz-bbj" id="4aX-HB-OFa"/>
                 <outlet property="localVideoView" destination="AOt-yj-kPb" id="Dck-BK-47J"/>
                 <outlet property="view" destination="iN0-l3-epB" id="t0K-uJ-o5K"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="iN0-l3-epB">
-            <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
+            <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N0c-WK-c8E">
@@ -29,18 +28,9 @@
                     </connections>
                 </button>
                 <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AOt-yj-kPb" userLabel="LocalView">
-                    <rect key="frame" x="231.5" y="480.5" width="772.5" height="865.5"/>
+                    <rect key="frame" x="231.66666666666663" y="480.66666666666674" width="141.33333333333337" height="351.33333333333326"/>
                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </view>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="EEy-nz-bbj">
-                    <rect key="frame" x="0.0" y="58" width="120" height="35"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                    <state key="normal" title="Button"/>
-                    <buttonConfiguration key="configuration" style="plain" title="Join Session"/>
-                    <connections>
-                        <action selector="joinStorageSession:" destination="-1" eventType="touchUpInside" id="iOt-88-doA"/>
-                    </connections>
-                </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="CYb-ul-ZkI"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Swift/Podfile
+++ b/Swift/Podfile
@@ -9,6 +9,7 @@ target 'AWSKinesisVideoWebRTCDemoApp' do
   pod 'CommonCryptoModule'
   pod 'AWSKinesisVideo'
   pod 'AWSKinesisVideoSignaling'
+  pod 'AWSKinesisVideoWebRTCStorage'
   pod 'GoogleWebRTC', '~> 1.1'
   pod 'Starscream', '~> 3.0'
   	target 'AWSKinesisVideoWebRTCDemoAppUITests' do


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
## What's new

- Implemented master and viewer participant WebRTC connection establishment with the KVS WebRTC storage session. (#107)

## Bug fixes and improvements

### SDK

- Resolved a build issue due to WebSocket namespace conflict in iOS 26. (#99)
- Fixed an issue with the KVSSigner when using 12-hour format. (#94)
- Adjusted the ICE candidate string parsing logic to allow SDPMID field to be optional. (#107)

### Sample App

- Adjusted the project configuration to exclude arm64 emulator architectures. (#103)
- Implemented a toast UI element for WebRTC connected/disconnected events. (#107)
- Implemented a "send video" configuration option. (#107)
- Implemented a resolution selector configuration option. (#105)
- Fixed the UI label for the "send audio" configuration option. (#107)
- Fixed an issue where the ICE candidates would get stuck in the pending queue if they were received from KVS Signaling before the SDP offer. (#107)
- Resolved runtime warnings in the sample app. (#102, #107)

## Developer Enhancements
- Configured the CI/CD to also run on the develop branch. (#109)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
