### PR TITLE
Dual-Stack Endpoint Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,8 @@ jobs:
     strategy:
       matrix:
         config: [
-          {mac_ver: "13", xc_ver: "15.2", os: "17.2", iphone_ver: "14"},
-          {mac_ver: "14", xc_ver: "15.4", os: "17.5", iphone_ver: "15"},
+          {mac_ver: "15-intel", xc_ver: "16.4", os: "18.6", iphone_ver: "16e"},
+          {mac_ver: "15-intel", xc_ver: "16.4", os: "18.6", iphone_ver: "16 Pro"},
           {mac_ver: "15", xc_ver: "16.4", os: "18.6", iphone_ver: "16e"},
           {mac_ver: "15", xc_ver: "16.4", os: "18.6", iphone_ver: "16 Pro"}
         ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         config: [
-          {mac_ver: "13", xc_ver: "15.2", os: "17.2", iphone_ver: "14"},
-          {mac_ver: "14", xc_ver: "15.4", os: "17.5", iphone_ver: "15"},
+          {mac_ver: "15-intel", xc_ver: "16.4", os: "18.6", iphone_ver: "16e"},
+          {mac_ver: "15-intel", xc_ver: "16.4", os: "18.6", iphone_ver: "16 Pro"},
           {mac_ver: "15", xc_ver: "16.4", os: "18.6", iphone_ver: "16e"},
           {mac_ver: "15", xc_ver: "16.4", os: "18.6", iphone_ver: "16 Pro"}
         ]

--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -438,7 +438,13 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
     func getIceCandidates(channelARN: String, endpoint: AWSEndpoint, regionType: AWSRegionType, clientId: String) -> [RTCIceServer] {
         var RTCIceServersList = [RTCIceServer]()
         // TODO: don't use the self.regionName.text!
-        let kvsStunUrlStrings = ["stun:stun.kinesisvideo." + self.regionName.text! + ".amazonaws.com:443"]
+    
+        let kvsStunUrlStrings: [String]
+        if self.useDualStackKvsEndpoint {
+            kvsStunUrlStrings = ["stun:stun.kinesisvideo." + self.regionName.text! + ".api.aws:443"]
+        } else {
+            kvsStunUrlStrings = ["stun:stun.kinesisvideo." + self.regionName.text! + ".amazonaws.com:443"]
+        }
         /*
             equivalent AWS CLI command:
             aws kinesis-video-signaling get-ice-server-config --channel-arn channelARN --client-id clientId --region cognitoIdentityUserPoolRegion

--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -82,6 +82,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         return AWSMobileClient.default()
     }
 
+    // Helper function to get KVS endpoint override if specified.
     private func getKvsEndpointOverride()-> String? {
 
         // Environment variable override takes precedence.
@@ -118,6 +119,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         super.viewDidLoad()
         self.signalingConnected = false
         updateConnectionLabel()
+        animateEndpointLabels(isDualStackOn: useDualStackKvsEndpointSwitch.isOn)
 
         channelName.delegate = self
         clientID.delegate = self
@@ -141,8 +143,34 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         navigationController?.setToolbarHidden(false, animated: true)
     }
 
+    @IBOutlet weak var legacyLabel: UILabel!
+    @IBOutlet weak var dualStackLabel: UILabel!
+    
+    let endpointLabelAlpha_selected: CGFloat = 1.0
+    let endpointLabelAlpha_deselected: CGFloat = 0.7
+    let animation transitionDuration: TimeInterval = 0.3
+
+    // Animate the legacy and dual-stack labels based on the switch state.
+    private func animateEndpointLabels(isDualStackOn: Bool) {
+        let baseFont = UIFont.systemFont(ofSize: self.legacyLabel.font.pointSize, weight: .regular)
+        let semiBoldFont = UIFont.systemFont(ofSize: self.legacyLabel.font.pointSize, weight: .semibold)
+
+        UIView.animate(withDuration: transitionDuration, delay: 0, options: [.curveEaseInOut], animations: {
+            self.dualStackLabel.alpha = isDualStackOn ? endpointLabelAlpha_selected : endpointLabelAlpha_deselected
+            self.legacyLabel.alpha = isDualStackOn ? endpointLabelAlpha_deselected : endpointLabelAlpha_selected
+        })
+
+        UIView.transition(with: dualStackLabel, duration: transitionDuration, options: .transitionCrossDissolve, animations: {
+            self.dualStackLabel.font = isDualStackOn ? semiBoldFont : baseFont
+        })
+        UIView.transition(with: legacyLabel, duration: transitionDuration, options: .transitionCrossDissolve, animations: {
+            self.legacyLabel.font = isDualStackOn ? baseFont : semiBoldFont
+        })
+    }
+
     @IBAction func kvsEndpointStateChanged(sender: UISwitch!) {
         self.useDualStackKvsEndpoint = sender.isOn
+        animateEndpointLabels(isDualStackOn: sender.isOn)
     }
 
     @IBAction func audioStateChanged(sender: UISwitch!) {

--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -148,7 +148,8 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
     
     let endpointLabelAlpha_selected: CGFloat = 1.0
     let endpointLabelAlpha_deselected: CGFloat = 0.7
-    let animation transitionDuration: TimeInterval = 0.3
+    let transitionDuration: TimeInterval = 0.3
+    
 
     // Animate the legacy and dual-stack labels based on the switch state.
     private func animateEndpointLabels(isDualStackOn: Bool) {
@@ -156,8 +157,8 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         let semiBoldFont = UIFont.systemFont(ofSize: self.legacyLabel.font.pointSize, weight: .semibold)
 
         UIView.animate(withDuration: transitionDuration, delay: 0, options: [.curveEaseInOut], animations: {
-            self.dualStackLabel.alpha = isDualStackOn ? endpointLabelAlpha_selected : endpointLabelAlpha_deselected
-            self.legacyLabel.alpha = isDualStackOn ? endpointLabelAlpha_deselected : endpointLabelAlpha_selected
+            self.dualStackLabel.alpha = isDualStackOn ? self.endpointLabelAlpha_selected : self.endpointLabelAlpha_deselected
+            self.legacyLabel.alpha = isDualStackOn ? self.endpointLabelAlpha_deselected : self.endpointLabelAlpha_selected
         })
 
         UIView.transition(with: dualStackLabel, duration: transitionDuration, options: .transitionCrossDissolve, animations: {

--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -119,7 +119,6 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         super.viewDidLoad()
         self.signalingConnected = false
         updateConnectionLabel()
-        animateEndpointLabels(isDualStackOn: useDualStackKvsEndpointSwitch.isOn)
 
         channelName.delegate = self
         clientID.delegate = self
@@ -143,35 +142,8 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         navigationController?.setToolbarHidden(false, animated: true)
     }
 
-    @IBOutlet weak var legacyLabel: UILabel!
-    @IBOutlet weak var dualStackLabel: UILabel!
-    
-    let endpointLabelAlpha_selected: CGFloat = 1.0
-    let endpointLabelAlpha_deselected: CGFloat = 0.7
-    let transitionDuration: TimeInterval = 0.3
-    
-
-    // Animate the legacy and dual-stack labels based on the switch state.
-    private func animateEndpointLabels(isDualStackOn: Bool) {
-        let baseFont = UIFont.systemFont(ofSize: self.legacyLabel.font.pointSize, weight: .regular)
-        let semiBoldFont = UIFont.systemFont(ofSize: self.legacyLabel.font.pointSize, weight: .semibold)
-
-        UIView.animate(withDuration: transitionDuration, delay: 0, options: [.curveEaseInOut], animations: {
-            self.dualStackLabel.alpha = isDualStackOn ? self.endpointLabelAlpha_selected : self.endpointLabelAlpha_deselected
-            self.legacyLabel.alpha = isDualStackOn ? self.endpointLabelAlpha_deselected : self.endpointLabelAlpha_selected
-        })
-
-        UIView.transition(with: dualStackLabel, duration: transitionDuration, options: .transitionCrossDissolve, animations: {
-            self.dualStackLabel.font = isDualStackOn ? semiBoldFont : baseFont
-        })
-        UIView.transition(with: legacyLabel, duration: transitionDuration, options: .transitionCrossDissolve, animations: {
-            self.legacyLabel.font = isDualStackOn ? baseFont : semiBoldFont
-        })
-    }
-
     @IBAction func kvsEndpointStateChanged(sender: UISwitch!) {
         self.useDualStackKvsEndpoint = sender.isOn
-        animateEndpointLabels(isDualStackOn: sender.isOn)
     }
 
     @IBAction func audioStateChanged(sender: UISwitch!) {

--- a/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
+++ b/Swift/KVSiOSApp/ChannelConfigurationViewController.swift
@@ -37,6 +37,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
     var isMaster: Bool = false
     var signalingConnected: Bool = false
     var selectedResolution: VideoResolution = .resolution720p
+    var useDualStackKvsEndpoint: Bool = false
 
     // clients for WEBRTC Connection
     var signalingClient: SignalingClient?
@@ -53,6 +54,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
     @IBOutlet var channelName: UITextField!
     @IBOutlet var clientID: UITextField!
     @IBOutlet var regionName: UITextField!
+    @IBOutlet var useDualStackKvsEndpointSwitch: UISwitch!
     @IBOutlet var isAudioEnabled: UISwitch!
     @IBOutlet var isVideoEnabled: UISwitch!
     @IBOutlet var resolutionButton: UIButton!
@@ -79,6 +81,32 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         }
         return AWSMobileClient.default()
     }
+
+    private func getKvsEndpointOverride()-> String? {
+
+        // Environment variable override takes precedence.
+        if let envVarOverride = kvsControlPlaneOverride, !envVarOverride.isEmpty {
+            return envVarOverride
+        }
+
+        // If using dual-stack endpoint format, construct the appropriate endpoint using the region name.
+        if self.useDualStackKvsEndpoint {
+
+            guard let regionText = self.regionName.text?.trim(),
+                !regionText.isEmpty else {
+                return nil
+            }
+
+            if regionText.hasPrefix("cn-") {
+                return String(format: PROD_CONTROL_PLANE_ENDPOINT_FORMAT_DUAL_STACK_CN, regionText)
+            }
+
+            return String(format: PROD_CONTROL_PLANE_ENDPOINT_FORMAT_DUAL_STACK, regionText)
+        }
+
+        return nil
+    }
+
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(true)
@@ -113,20 +141,16 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         navigationController?.setToolbarHidden(false, animated: true)
     }
 
+    @IBAction func kvsEndpointStateChanged(sender: UISwitch!) {
+        self.useDualStackKvsEndpoint = sender.isOn
+    }
+
     @IBAction func audioStateChanged(sender: UISwitch!) {
-        if sender.isOn {
-            self.sendAudioEnabled = true
-        } else {
-            self.sendAudioEnabled = false
-        }
+        self.sendAudioEnabled = sender.isOn
     }
 
     @IBAction func videoStateChanged(sender: UISwitch!) {
-        if sender.isOn {
-            self.sendVideoEnabled = true
-        } else {
-            self.sendVideoEnabled = false
-        }
+        self.sendVideoEnabled = sender.isOn
     }
 
     @IBAction func resolutionButtonTapped(_ sender: UIButton) {
@@ -221,7 +245,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         }
         // Kinesis Video Client Configuration
         let configuration = AWSServiceConfiguration(region: awsRegionType,
-                                                    endpoint: kvsControlPlaneOverride.map { AWSEndpoint(urlString: $0) },
+                                                    endpoint: getKvsEndpointOverride().map { AWSEndpoint(urlString: $0) },
                                                     credentialsProvider: getCredentialsProvider())
         AWSKinesisVideo.register(with: configuration!, forKey: awsKinesisVideoKey)
 
@@ -252,7 +276,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
         }
 
         // get signalling channel endpoints
-        let endpoints = getSignallingEndpoints(channelARN: channelARN!, region: awsRegionValue, isMaster: self.isMaster, useStorageSession: useStorageSession)
+        let endpoints = getSignallingEndpoints(channelARN: channelARN!, awsRegionValue: awsRegionValue, isMaster: self.isMaster, useStorageSession: useStorageSession)
         //// Ensure that the WebSocket (WSS) endpoint is available; WebRTC requires a valid signaling endpoint.
         if endpoints["WSS"] == nil {
             popUpError(title: "Invalid SignallingEndpoints", message: "SignallingEndpoints is required for WebRTC connection")
@@ -418,7 +442,7 @@ class ChannelConfigurationViewController: UIViewController, UITextFieldDelegate 
     }
    
     // Get signalling endpoints for the given signalling channel ARN 
-    func getSignallingEndpoints(channelARN: String, region: String, isMaster: Bool, useStorageSession: Bool) -> Dictionary<String, String?> {
+    func getSignallingEndpoints(channelARN: String, awsRegionValue: String, isMaster: Bool, useStorageSession: Bool) -> Dictionary<String, String?> {
         
         var endpoints = Dictionary <String, String?>()
         /*

--- a/Swift/KVSiOSApp/Constants.swift
+++ b/Swift/KVSiOSApp/Constants.swift
@@ -59,3 +59,7 @@ let awsAccessKey: String? = ProcessInfo.processInfo.environment["AWS_ACCESS_KEY_
 let awsSecretKey: String? = ProcessInfo.processInfo.environment["AWS_SECRET_ACCESS_KEY"]
 let awsSessionToken: String? = ProcessInfo.processInfo.environment["AWS_SESSION_TOKEN"]
 let kvsControlPlaneOverride: String? = ProcessInfo.processInfo.environment["CONTROL_PLANE_URI"]
+
+// Dual-stack endpoint formats.
+let PROD_CONTROL_PLANE_ENDPOINT_FORMAT_DUAL_STACK = "https://kinesisvideo.%@.api.aws"
+let PROD_CONTROL_PLANE_ENDPOINT_FORMAT_DUAL_STACK_CN = "https://kinesisvideo.%@.api.amazonwebservices.com.cn"

--- a/Swift/KVSiOSApp/Main.storyboard
+++ b/Swift/KVSiOSApp/Main.storyboard
@@ -615,21 +615,21 @@
                                                 <rect key="frame" x="0.0" y="22" width="243" height="31"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Legacy" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="umz-uu-SIf">
-                                                        <rect key="frame" x="24" y="6.5" width="49.5" height="18"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                        <rect key="frame" x="24" y="7" width="46.5" height="17"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <switch opaque="NO" contentMode="center" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" title="KVS Endpoint Type" translatesAutoresizingMaskIntoConstraints="NO" id="rin-LU-Fkr" userLabel="KVS Endpoint Type">
-                                                        <rect key="frame" x="84.5" y="0.0" width="51" height="31"/>
+                                                        <rect key="frame" x="85" y="0.0" width="51" height="31"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="kvsEndpointTypeSwitch"/>
                                                         <connections>
                                                             <action selector="kvsEndpointStateChangedWithSender:" destination="fxY-gB-7Yj" eventType="valueChanged" id="arq-uB-UFD"/>
                                                         </connections>
                                                     </switch>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dual-stack" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="5Jb-mZ-Lhl">
-                                                        <rect key="frame" x="144.5" y="6.5" width="74.5" height="18"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                        <rect key="frame" x="148.5" y="7" width="70.5" height="17"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
@@ -761,8 +761,10 @@
                         <outlet property="connectAsMasterButton" destination="3k1-42-Mbg" id="SsG-ss-9bL"/>
                         <outlet property="connectAsViewerButton" destination="KMq-bs-4Hv" id="HDg-vF-0CB"/>
                         <outlet property="connectedLabel" destination="NOw-C6-Bie" id="cMG-kR-3E9"/>
+                        <outlet property="dualStackLabel" destination="5Jb-mZ-Lhl" id="dIO-qL-AwB"/>
                         <outlet property="isAudioEnabled" destination="uWn-mC-EnS" id="CUs-sB-mgl"/>
                         <outlet property="isVideoEnabled" destination="Z0n-7n-HzH" id="q4o-zH-9LY"/>
+                        <outlet property="legacyLabel" destination="umz-uu-SIf" id="xvY-pq-11Z"/>
                         <outlet property="regionName" destination="nr9-tN-CuW" id="tX6-zd-Kpw"/>
                         <outlet property="resolutionButton" destination="res-btn-123" id="res-outlet-123"/>
                         <outlet property="useDualStackKvsEndpointSwitch" destination="rin-LU-Fkr" id="e7a-sc-PVQ"/>

--- a/Swift/KVSiOSApp/Main.storyboard
+++ b/Swift/KVSiOSApp/Main.storyboard
@@ -566,7 +566,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="kmG-RW-rZ0">
-                                        <rect key="frame" x="0.0" y="63.5" width="243" height="103"/>
+                                        <rect key="frame" x="0.0" y="77" width="243" height="103"/>
                                         <subviews>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Channel Name " textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zEP-tC-ik7">
                                                 <rect key="frame" x="0.0" y="0.0" width="243" height="25"/>
@@ -597,49 +597,8 @@
                                             </textField>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="7jW-e1-Anr">
-                                        <rect key="frame" x="0.0" y="190" width="243" height="53"/>
-                                        <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="ymZ-2T-Enz">
-                                                <rect key="frame" x="0.0" y="0.0" width="243" height="17"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="KVS Endpoint Type" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sUl-7W-tTx">
-                                                        <rect key="frame" x="0.0" y="0.0" width="243" height="17"/>
-                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                            </stackView>
-                                            <stackView opaque="NO" contentMode="center" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jPH-dG-OBo">
-                                                <rect key="frame" x="0.0" y="22" width="243" height="31"/>
-                                                <subviews>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Legacy" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="umz-uu-SIf">
-                                                        <rect key="frame" x="24" y="7" width="46.5" height="17"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                    <switch opaque="NO" contentMode="center" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" title="KVS Endpoint Type" translatesAutoresizingMaskIntoConstraints="NO" id="rin-LU-Fkr" userLabel="KVS Endpoint Type">
-                                                        <rect key="frame" x="85" y="0.0" width="51" height="31"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="kvsEndpointTypeSwitch"/>
-                                                        <connections>
-                                                            <action selector="kvsEndpointStateChangedWithSender:" destination="fxY-gB-7Yj" eventType="valueChanged" id="arq-uB-UFD"/>
-                                                        </connections>
-                                                    </switch>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dual-stack" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="5Jb-mZ-Lhl">
-                                                        <rect key="frame" x="148.5" y="7" width="70.5" height="17"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <nil key="textColor"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
-                                                </subviews>
-                                                <edgeInsets key="layoutMargins" top="0.0" left="24" bottom="0.0" right="24"/>
-                                            </stackView>
-                                        </subviews>
-                                    </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="UD9-M2-qiC">
-                                        <rect key="frame" x="0.0" y="266.5" width="243" height="103"/>
+                                        <rect key="frame" x="0.0" y="192" width="243" height="103"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="res-btn-123">
                                                 <rect key="frame" x="0.0" y="0.0" width="243" height="25"/>
@@ -688,7 +647,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="X20-Nx-f2Q">
-                                        <rect key="frame" x="0.0" y="381.5" width="243" height="76"/>
+                                        <rect key="frame" x="0.0" y="320.5" width="243" height="76"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YHE-xZ-R4i">
                                                 <rect key="frame" x="0.0" y="0.0" width="243" height="31"/>
@@ -728,6 +687,41 @@
                                             </stackView>
                                         </subviews>
                                     </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="7jW-e1-Anr">
+                                        <rect key="frame" x="0.0" y="423.5" width="243" height="53"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="ymZ-2T-Enz">
+                                                <rect key="frame" x="0.0" y="0.0" width="243" height="17"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="KVS Endpoint Type" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sUl-7W-tTx">
+                                                        <rect key="frame" x="0.0" y="0.0" width="243" height="17"/>
+                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="center" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jPH-dG-OBo">
+                                                <rect key="frame" x="0.0" y="22" width="243" height="31"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dual-stack" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="5Jb-mZ-Lhl">
+                                                        <rect key="frame" x="24" y="7" width="70.5" height="17"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <switch opaque="NO" contentMode="center" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" title="KVS Endpoint Type" translatesAutoresizingMaskIntoConstraints="NO" id="rin-LU-Fkr" userLabel="KVS Endpoint Type">
+                                                        <rect key="frame" x="170" y="0.0" width="51" height="31"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="kvsEndpointTypeSwitch"/>
+                                                        <connections>
+                                                            <action selector="kvsEndpointStateChangedWithSender:" destination="fxY-gB-7Yj" eventType="valueChanged" id="arq-uB-UFD"/>
+                                                        </connections>
+                                                    </switch>
+                                                </subviews>
+                                                <edgeInsets key="layoutMargins" top="0.0" left="24" bottom="0.0" right="24"/>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
                                     <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Not Connected" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="NOw-C6-Bie">
                                         <rect key="frame" x="0.0" y="488.5" width="243" height="14.5"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
@@ -761,10 +755,8 @@
                         <outlet property="connectAsMasterButton" destination="3k1-42-Mbg" id="SsG-ss-9bL"/>
                         <outlet property="connectAsViewerButton" destination="KMq-bs-4Hv" id="HDg-vF-0CB"/>
                         <outlet property="connectedLabel" destination="NOw-C6-Bie" id="cMG-kR-3E9"/>
-                        <outlet property="dualStackLabel" destination="5Jb-mZ-Lhl" id="dIO-qL-AwB"/>
                         <outlet property="isAudioEnabled" destination="uWn-mC-EnS" id="CUs-sB-mgl"/>
                         <outlet property="isVideoEnabled" destination="Z0n-7n-HzH" id="q4o-zH-9LY"/>
-                        <outlet property="legacyLabel" destination="umz-uu-SIf" id="xvY-pq-11Z"/>
                         <outlet property="regionName" destination="nr9-tN-CuW" id="tX6-zd-Kpw"/>
                         <outlet property="resolutionButton" destination="res-btn-123" id="res-outlet-123"/>
                         <outlet property="useDualStackKvsEndpointSwitch" destination="rin-LU-Fkr" id="e7a-sc-PVQ"/>

--- a/Swift/KVSiOSApp/Main.storyboard
+++ b/Swift/KVSiOSApp/Main.storyboard
@@ -623,6 +623,9 @@
                                                     <switch opaque="NO" contentMode="center" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" title="KVS Endpoint Type" translatesAutoresizingMaskIntoConstraints="NO" id="rin-LU-Fkr" userLabel="KVS Endpoint Type">
                                                         <rect key="frame" x="84.5" y="0.0" width="51" height="31"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="kvsEndpointTypeSwitch"/>
+                                                        <connections>
+                                                            <action selector="kvsEndpointStateChangedWithSender:" destination="fxY-gB-7Yj" eventType="valueChanged" id="arq-uB-UFD"/>
+                                                        </connections>
                                                     </switch>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dual-stack" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="5Jb-mZ-Lhl">
                                                         <rect key="frame" x="144.5" y="6.5" width="74.5" height="18"/>
@@ -762,6 +765,7 @@
                         <outlet property="isVideoEnabled" destination="Z0n-7n-HzH" id="q4o-zH-9LY"/>
                         <outlet property="regionName" destination="nr9-tN-CuW" id="tX6-zd-Kpw"/>
                         <outlet property="resolutionButton" destination="res-btn-123" id="res-outlet-123"/>
+                        <outlet property="useDualStackKvsEndpointSwitch" destination="rin-LU-Fkr" id="e7a-sc-PVQ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="7NB-jG-Ywn" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Swift/KVSiOSApp/Main.storyboard
+++ b/Swift/KVSiOSApp/Main.storyboard
@@ -562,7 +562,7 @@
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="KVS WebRTC on iOS" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IHb-vd-SSF">
                                         <rect key="frame" x="0.0" y="0.0" width="243" height="26.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
-                                        <nil key="textColor"/>
+                                        <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="kmG-RW-rZ0">
@@ -696,7 +696,7 @@
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="KVS Endpoint Type" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sUl-7W-tTx">
                                                         <rect key="frame" x="0.0" y="0.0" width="243" height="17"/>
                                                         <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
-                                                        <nil key="textColor"/>
+                                                        <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
@@ -707,7 +707,7 @@
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dual-stack" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="5Jb-mZ-Lhl">
                                                         <rect key="frame" x="24" y="7" width="70.5" height="17"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <nil key="textColor"/>
+                                                        <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <switch opaque="NO" contentMode="center" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" title="KVS Endpoint Type" translatesAutoresizingMaskIntoConstraints="NO" id="rin-LU-Fkr" userLabel="KVS Endpoint Type">
@@ -782,7 +782,7 @@
                                 <rect key="frame" x="12" y="78" width="350" height="405"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Gka-28-A0V">
-                                        <rect key="frame" x="0.0" y="0.0" width="350" height="200"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="350" height="180"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="350" id="845-y2-BGp"/>
@@ -790,7 +790,7 @@
                                         </constraints>
                                     </view>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jnz-Q7-NG2">
-                                        <rect key="frame" x="0.0" y="200" width="350" height="180"/>
+                                        <rect key="frame" x="0.0" y="180" width="350" height="200"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="200" id="EqQ-9O-HQK"/>

--- a/Swift/KVSiOSApp/Main.storyboard
+++ b/Swift/KVSiOSApp/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="24127" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="SfA-Z0-41u">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="SfA-Z0-41u">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -117,13 +117,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Username" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6BZ-sc-Lc1">
-                                <rect key="frame" x="17" y="105" width="343" height="34"/>
+                                <rect key="frame" x="17" y="95" width="343" height="34"/>
                                 <accessibility key="accessibilityConfiguration" identifier="forgotpasswordusernametextfield"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="alphabet"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ibj-ub-Te0">
-                                <rect key="frame" x="17" y="82" width="64" height="21"/>
+                                <rect key="frame" x="17" y="72" width="64" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="ZQ7-Ss-COS"/>
                                     <constraint firstAttribute="width" constant="64" id="x6w-ch-LfX"/>
@@ -133,7 +133,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="AeR-Mz-1Zm">
-                                <rect key="frame" x="17" y="147" width="343" height="34"/>
+                                <rect key="frame" x="17" y="137" width="343" height="34"/>
                                 <color key="backgroundColor" red="0.1960784314" green="0.60392156860000001" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="forgotpasswordviewforgotpasswordbutton"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
@@ -238,7 +238,7 @@
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="emailAddress"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rGl-pc-v5L">
-                                <rect key="frame" x="16" y="82" width="58" height="10"/>
+                                <rect key="frame" x="16" y="72" width="58" height="20"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -338,7 +338,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Username" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gnv-sz-M9A">
-                                <rect key="frame" x="16" y="111" width="58" height="21"/>
+                                <rect key="frame" x="16" y="101" width="58" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="Led-iP-103"/>
                                 </constraints>
@@ -347,12 +347,12 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Username" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="qBV-Yn-oTi">
-                                <rect key="frame" x="16" y="140" width="343" height="34"/>
+                                <rect key="frame" x="16" y="130" width="343" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="alphabet"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Confirmation Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DPa-qj-OwO">
-                                <rect key="frame" x="16" y="182" width="107" height="19"/>
+                                <rect key="frame" x="16" y="172" width="107" height="19"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="19" id="AFe-FI-SOc"/>
                                 </constraints>
@@ -361,7 +361,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Confirmation Code" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5ip-nQ-ff9">
-                                <rect key="frame" x="16" y="209" width="343" height="34"/>
+                                <rect key="frame" x="16" y="199" width="343" height="34"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="phonePad"/>
                             </textField>
@@ -373,7 +373,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2AX-rN-0c4">
-                                <rect key="frame" x="16" y="251" width="343" height="34"/>
+                                <rect key="frame" x="16" y="241" width="343" height="34"/>
                                 <color key="backgroundColor" red="0.1960784314" green="0.60392156860000001" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                 <state key="normal" title="Confirm">
@@ -384,7 +384,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Vcr-l8-gne">
-                                <rect key="frame" x="16" y="293" width="185" height="30"/>
+                                <rect key="frame" x="16" y="283" width="185" height="30"/>
                                 <state key="normal" title="Resend Confirmation Code"/>
                                 <connections>
                                     <action selector="resend:" destination="52d-g9-hr2" eventType="touchUpInside" id="wB3-WA-kIm"/>
@@ -427,7 +427,7 @@
                 <navigationController storyboardIdentifier="signinController" automaticallyAdjustsScrollViewInsets="NO" id="u8p-Q9-nvF" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="QPf-uA-9bC">
-                        <rect key="frame" x="0.0" y="20" width="375" height="54"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -455,13 +455,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Confirmation Code" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="s02-hv-Uoj">
-                                <rect key="frame" x="17" y="105" width="343" height="34"/>
+                                <rect key="frame" x="17" y="95" width="343" height="34"/>
                                 <accessibility key="accessibilityConfiguration" identifier="confirmforgotpasswordconfirmationcodetextfield"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="numberPad"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Confirmation Code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WVP-Ye-b3s">
-                                <rect key="frame" x="17" y="82" width="114" height="21"/>
+                                <rect key="frame" x="17" y="72" width="114" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="114" id="Sin-cE-5n6"/>
                                     <constraint firstAttribute="height" constant="21" id="bdP-Kx-LIq"/>
@@ -471,13 +471,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="New Password" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="FgX-KG-zLK">
-                                <rect key="frame" x="17" y="170" width="343" height="34"/>
+                                <rect key="frame" x="17" y="160" width="343" height="34"/>
                                 <accessibility key="accessibilityConfiguration" identifier="confirmforgotpasswordnewpasswordtextfield"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="alphabet" secureTextEntry="YES"/>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="New Password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yfQ-Se-BxR">
-                                <rect key="frame" x="16" y="147" width="107" height="21"/>
+                                <rect key="frame" x="16" y="137" width="107" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="JkO-bD-tlb"/>
                                     <constraint firstAttribute="width" constant="107" id="nTp-c4-eBa"/>
@@ -487,7 +487,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jfj-m7-W5X">
-                                <rect key="frame" x="17" y="208" width="343" height="34"/>
+                                <rect key="frame" x="17" y="198" width="343" height="34"/>
                                 <color key="backgroundColor" red="0.1960784314" green="0.60392156860000001" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <accessibility key="accessibilityConfiguration" identifier="confirmforgotpasswordupdatepasswordbutton"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
@@ -532,7 +532,7 @@
                 <navigationController storyboardIdentifier="channelConfig" automaticallyAdjustsScrollViewInsets="NO" id="SfA-Z0-41u" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="0b4-Wk-FS7">
-                        <rect key="frame" x="0.0" y="20" width="375" height="54"/>
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -552,122 +552,179 @@
                         <viewControllerLayoutGuide type="top" id="719-2R-FoQ"/>
                         <viewControllerLayoutGuide type="bottom" id="xzu-VI-sNV"/>
                     </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="PaL-Mo-bUW">
+                    <view key="view" contentMode="center" id="PaL-Mo-bUW">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" axis="vertical" spacing="40" translatesAutoresizingMaskIntoConstraints="NO" id="4pf-3f-52M">
-                                <rect key="frame" x="66" y="74" width="243" height="564.5"/>
+                            <stackView opaque="NO" contentMode="bottom" preservesSuperviewLayoutMargins="YES" axis="vertical" distribution="equalCentering" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="4pf-3f-52M">
+                                <rect key="frame" x="66" y="64" width="243" height="503"/>
                                 <subviews>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Channel Name " textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zEP-tC-ik7">
-                                        <rect key="frame" x="0.0" y="0.0" width="243" height="25"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="channelnametextfield"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="25" id="Xmx-Xt-T0T"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits"/>
-                                    </textField>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Client ID (optional)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="a2V-fh-lBx">
-                                        <rect key="frame" x="0.0" y="65" width="243" height="25"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="clientidtextfield"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="25" id="drp-Hv-OMz"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits"/>
-                                    </textField>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Region" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nr9-tN-CuW">
-                                        <rect key="frame" x="0.0" y="130" width="243" height="25"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="regiontextfield"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="25" id="NqF-xK-94H"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <textInputTraits key="textInputTraits"/>
-                                    </textField>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="res-btn-123">
-                                        <rect key="frame" x="0.0" y="195" width="243" height="25"/>
-                                        <color key="backgroundColor" systemColor="systemGrayColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="25" id="res-height-123"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                        <state key="normal" title="1280x720">
-                                            <color key="titleColor" systemColor="labelColor"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="resolutionButtonTapped:" destination="fxY-gB-7Yj" eventType="touchUpInside" id="res-action-123"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3k1-42-Mbg">
-                                        <rect key="frame" x="0.0" y="260" width="243" height="25"/>
-                                        <color key="backgroundColor" red="0.1960784314" green="0.60392156860000001" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="connectasmasterbutton"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="25" id="IO6-mE-h8o"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                        <state key="normal" title="Connect as Master">
-                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="connectAsMaster:" destination="fxY-gB-7Yj" eventType="touchUpInside" id="fGH-cB-U7O"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KMq-bs-4Hv">
-                                        <rect key="frame" x="0.0" y="325" width="243" height="25"/>
-                                        <color key="backgroundColor" red="0.1960784314" green="0.60392156860000001" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="connectasviewerbutton"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="25" id="HjA-Zg-sFx"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
-                                        <state key="normal" title="Connect as Viewer">
-                                            <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="connectAsViewerWith_sender:" destination="fxY-gB-7Yj" eventType="touchUpInside" id="0T8-1E-4hO"/>
-                                        </connections>
-                                    </button>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="120" translatesAutoresizingMaskIntoConstraints="NO" id="YHE-xZ-R4i">
-                                        <rect key="frame" x="0.0" y="390" width="243" height="52"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="KVS WebRTC on iOS" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IHb-vd-SSF">
+                                        <rect key="frame" x="0.0" y="0.0" width="243" height="26.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="kmG-RW-rZ0">
+                                        <rect key="frame" x="0.0" y="63.5" width="243" height="103"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Send Video" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vLC-Za-qPN">
-                                                <rect key="frame" x="0.0" y="0.0" width="62" height="52"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="11"/>
-                                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" title="Is Video Enabled" translatesAutoresizingMaskIntoConstraints="NO" id="Z0n-7n-HzH">
-                                                <rect key="frame" x="182" y="0.0" width="63" height="52"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="audioswitch"/>
-                                                <connections>
-                                                    <action selector="videoStateChangedWithSender:" destination="fxY-gB-7Yj" eventType="valueChanged" id="Vqg-xx-bxL"/>
-                                                </connections>
-                                            </switch>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Channel Name " textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zEP-tC-ik7">
+                                                <rect key="frame" x="0.0" y="0.0" width="243" height="25"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="channelnametextfield"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="25" id="Xmx-Xt-T0T"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Client ID (optional)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="a2V-fh-lBx">
+                                                <rect key="frame" x="0.0" y="39" width="243" height="25"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="clientidtextfield"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="25" id="drp-Hv-OMz"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Region" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nr9-tN-CuW">
+                                                <rect key="frame" x="0.0" y="78" width="243" height="25"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="regiontextfield"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="25" id="NqF-xK-94H"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
                                         </subviews>
                                     </stackView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" spacing="120" translatesAutoresizingMaskIntoConstraints="NO" id="G8H-J9-l8I">
-                                        <rect key="frame" x="0.0" y="482" width="243" height="28"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="7jW-e1-Anr">
+                                        <rect key="frame" x="0.0" y="190" width="243" height="53"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Send Audio" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pV1-OS-ahX">
-                                                <rect key="frame" x="0.0" y="0.0" width="62" height="28"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="11"/>
-                                                <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uWn-mC-EnS">
-                                                <rect key="frame" x="182" y="0.0" width="63" height="28"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="audioswitch"/>
+                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="ymZ-2T-Enz">
+                                                <rect key="frame" x="0.0" y="0.0" width="243" height="17"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="KVS Endpoint Type" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sUl-7W-tTx">
+                                                        <rect key="frame" x="0.0" y="0.0" width="243" height="17"/>
+                                                        <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="center" distribution="equalCentering" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jPH-dG-OBo">
+                                                <rect key="frame" x="0.0" y="22" width="243" height="31"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Legacy" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="umz-uu-SIf">
+                                                        <rect key="frame" x="0.0" y="6.5" width="49.5" height="18"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <switch opaque="NO" contentMode="center" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" title="KVS Endpoint Type" translatesAutoresizingMaskIntoConstraints="NO" id="rin-LU-Fkr">
+                                                        <rect key="frame" x="91" y="0.0" width="51" height="31"/>
+                                                    </switch>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dual-stack" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="5Jb-mZ-Lhl">
+                                                        <rect key="frame" x="168.5" y="6.5" width="74.5" height="18"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="UD9-M2-qiC">
+                                        <rect key="frame" x="0.0" y="266.5" width="243" height="103"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="res-btn-123">
+                                                <rect key="frame" x="0.0" y="0.0" width="243" height="25"/>
+                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="25" id="res-height-123"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <state key="normal" title="1280x720">
+                                                    <color key="titleColor" systemColor="labelColor"/>
+                                                </state>
                                                 <connections>
-                                                    <action selector="audioStateChangedWithSender:" destination="fxY-gB-7Yj" eventType="valueChanged" id="qaN-7b-Hmo"/>
+                                                    <action selector="resolutionButtonTapped:" destination="fxY-gB-7Yj" eventType="touchUpInside" id="res-action-123"/>
                                                 </connections>
-                                            </switch>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3k1-42-Mbg">
+                                                <rect key="frame" x="0.0" y="39" width="243" height="25"/>
+                                                <color key="backgroundColor" red="0.1960784314" green="0.60392156860000001" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="connectasmasterbutton"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="25" id="IO6-mE-h8o"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                <state key="normal" title="Connect as Master">
+                                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="connectAsMaster:" destination="fxY-gB-7Yj" eventType="touchUpInside" id="fGH-cB-U7O"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KMq-bs-4Hv">
+                                                <rect key="frame" x="0.0" y="78" width="243" height="25"/>
+                                                <color key="backgroundColor" red="0.1960784314" green="0.60392156860000001" blue="0.83921568629999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="connectasviewerbutton"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="25" id="HjA-Zg-sFx"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                                <state key="normal" title="Connect as Viewer">
+                                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                </state>
+                                                <connections>
+                                                    <action selector="connectAsViewerWith_sender:" destination="fxY-gB-7Yj" eventType="touchUpInside" id="0T8-1E-4hO"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="X20-Nx-f2Q">
+                                        <rect key="frame" x="0.0" y="381.5" width="243" height="76"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YHE-xZ-R4i">
+                                                <rect key="frame" x="0.0" y="0.0" width="243" height="31"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Send Video" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vLC-Za-qPN">
+                                                        <rect key="frame" x="0.0" y="0.0" width="194" height="31"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                        <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" title="Is Video Enabled" translatesAutoresizingMaskIntoConstraints="NO" id="Z0n-7n-HzH">
+                                                        <rect key="frame" x="194" y="0.0" width="51" height="31"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="audioswitch"/>
+                                                        <connections>
+                                                            <action selector="videoStateChangedWithSender:" destination="fxY-gB-7Yj" eventType="valueChanged" id="Vqg-xx-bxL"/>
+                                                        </connections>
+                                                    </switch>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="G8H-J9-l8I">
+                                                <rect key="frame" x="0.0" y="45" width="243" height="31"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Send Audio" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pV1-OS-ahX">
+                                                        <rect key="frame" x="0.0" y="0.0" width="194" height="31"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                        <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <switch opaque="NO" contentMode="center" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uWn-mC-EnS">
+                                                        <rect key="frame" x="194" y="0.0" width="51" height="31"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="audioswitch"/>
+                                                        <connections>
+                                                            <action selector="audioStateChangedWithSender:" destination="fxY-gB-7Yj" eventType="valueChanged" id="qaN-7b-Hmo"/>
+                                                        </connections>
+                                                    </switch>
+                                                </subviews>
+                                            </stackView>
                                         </subviews>
                                     </stackView>
                                     <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" text="Not Connected" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="NOw-C6-Bie">
-                                        <rect key="frame" x="0.0" y="550" width="243" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="488.5" width="243" height="14.5"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                         <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -778,7 +835,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemGrayColor">
-            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Swift/KVSiOSApp/Main.storyboard
+++ b/Swift/KVSiOSApp/Main.storyboard
@@ -611,25 +611,27 @@
                                                     </label>
                                                 </subviews>
                                             </stackView>
-                                            <stackView opaque="NO" contentMode="center" distribution="equalCentering" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jPH-dG-OBo">
+                                            <stackView opaque="NO" contentMode="center" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jPH-dG-OBo">
                                                 <rect key="frame" x="0.0" y="22" width="243" height="31"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Legacy" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="umz-uu-SIf">
-                                                        <rect key="frame" x="0.0" y="6.5" width="49.5" height="18"/>
+                                                        <rect key="frame" x="24" y="6.5" width="49.5" height="18"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <switch opaque="NO" contentMode="center" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" title="KVS Endpoint Type" translatesAutoresizingMaskIntoConstraints="NO" id="rin-LU-Fkr">
-                                                        <rect key="frame" x="91" y="0.0" width="51" height="31"/>
+                                                    <switch opaque="NO" contentMode="center" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" title="KVS Endpoint Type" translatesAutoresizingMaskIntoConstraints="NO" id="rin-LU-Fkr" userLabel="KVS Endpoint Type">
+                                                        <rect key="frame" x="84.5" y="0.0" width="51" height="31"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="kvsEndpointTypeSwitch"/>
                                                     </switch>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Dual-stack" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="8" translatesAutoresizingMaskIntoConstraints="NO" id="5Jb-mZ-Lhl">
-                                                        <rect key="frame" x="168.5" y="6.5" width="74.5" height="18"/>
+                                                        <rect key="frame" x="144.5" y="6.5" width="74.5" height="18"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
+                                                <edgeInsets key="layoutMargins" top="0.0" left="24" bottom="0.0" right="24"/>
                                             </stackView>
                                         </subviews>
                                     </stackView>


### PR DESCRIPTION
*Description of changes:*
- Added a switch to the UI to control whether to use dual-stack KVS endpoints.
- Improved the spacing of existing UI elements.
- Tested (ran the other peer on the [JS Test Page](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/index.html)) :
  - e2e WebRTC connection using a _pre-prod_ dual-stack control plane endpoint with the JS Test Page as the other peer.
  - e2e WebRTC connection with the switch set to "Legacy", checking for regressions when connecting to the legacy endpoint.
  - e2e WebRTC connection with the switch set to "Dual-stack", using the _prod_ dual-stack endpoint, which currently returns _legacy_ signaling endpoints.




<img width="300" height="1392" alt="image" src="https://github.com/user-attachments/assets/b818333d-bfe8-4ca2-8bdc-c465ea2a3e04" />


<br>
<br>
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
